### PR TITLE
feat: mypage api 연결

### DIFF
--- a/moigoFront/src/apis/apiClient.ts
+++ b/moigoFront/src/apis/apiClient.ts
@@ -17,7 +17,7 @@ export function setAccessToken(token: string | null) {
 }
 
 // 임시 토큰 설정 (개발용)
-setAccessToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidXNlcjEiLCJpYXQiOjE3NTQyMjY5NjEsImV4cCI6MTc1NDIzNDE2MX0.DCgiJAAzvXLNZ8e4_TqCO269u9j28bTa4c3N0mQOr6k');
+setAccessToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidXNlcjEiLCJpYXQiOjE3NTQyMzM3MjIsImV4cCI6MTc1NDI0MDkyMn0.r8pQolqTTF_HsHJWBZazysfpfAFBiVES4AeSOtzqqL8');
 
 apiClient.interceptors.request.use(
   (config) => {

--- a/moigoFront/src/components/common/CheckModal.tsx
+++ b/moigoFront/src/components/common/CheckModal.tsx
@@ -13,7 +13,7 @@ export default function CheckModal({ visible, title, onClose, children }: CheckM
     <Modal visible={visible} transparent animationType="fade" statusBarTranslucent={true}>
       <View className="flex-1 bg-black/50">
         <View className="flex-1" />
-        <View className="w-11/12 p-8 mx-auto bg-white shadow-lg rounded-3xl">{children}</View>
+        <View className="p-8 mx-auto w-11/12 bg-white rounded-3xl shadow-lg">{children}</View>
         <View className="flex-1" />
       </View>
     </Modal>

--- a/moigoFront/src/components/participatedMatches/MatchCard.tsx
+++ b/moigoFront/src/components/participatedMatches/MatchCard.tsx
@@ -10,6 +10,18 @@ interface MatchCardProps {
 }
 
 export default function MatchCard({ match, onWriteReview }: MatchCardProps) {
+  // 날짜를 문자열로 변환
+  const formatDate = (date: string | Date) => {
+    if (date instanceof Date) {
+      return date.toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      });
+    }
+    return date;
+  };
+
   return (
     <View className="p-4 mb-4 bg-white rounded-xl border border-gray-100 shadow-sm">
       {/* 제목 */}
@@ -19,7 +31,7 @@ export default function MatchCard({ match, onWriteReview }: MatchCardProps) {
       
       {/* 날짜와 시간 */}
       <Text className="mb-1 text-sm text-mainGrayText">
-        {match.date} {match.time}
+        {formatDate(match.date)} {match.time}
       </Text>
       
       {/* 위치 */}

--- a/moigoFront/src/components/review/ReviewModal.tsx
+++ b/moigoFront/src/components/review/ReviewModal.tsx
@@ -19,6 +19,19 @@ export default function ReviewModal({ visible, match, onClose, onSubmit }: Revie
   const [content, setContent] = useState('');
   const maxLength = 500;
 
+  // 날짜를 문자열로 변환
+  const formatDate = (date: string | Date | undefined) => {
+    if (!date) return '';
+    if (date instanceof Date) {
+      return date.toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      });
+    }
+    return date;
+  };
+
   const handleSubmit = () => {
     if (rating === 0) {
       // 별점을 선택하지 않은 경우 처리
@@ -49,7 +62,7 @@ export default function ReviewModal({ visible, match, onClose, onSubmit }: Revie
           <View className="flex-row items-center">
             <Feather name="calendar" size={16} color={COLORS.mainGrayText} />
             <Text className="ml-2 text-sm text-mainGrayText">
-              {match?.date} {match?.time}
+              {formatDate(match?.date)} {match?.time}
             </Text>
           </View>
         </View>

--- a/moigoFront/src/hooks/queries/useAuthQueries.ts
+++ b/moigoFront/src/hooks/queries/useAuthQueries.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { signup, login, logout } from '../../apis/auth';
 import type { SignupRequestDTO, LoginRequestDTO } from '../../types/DTO/auth';
 import { setAccessToken } from '../../apis/apiClient';
+import { useMyStore } from '../../store/myStore';
 
 // POST /auth/signup - 회원가입 훅
 export const useSignup = () => {
@@ -15,11 +16,28 @@ export const useSignup = () => {
 
 // POST /auth/login - 로그인 훅
 export const useLogin = () => {
+  const { updateUserProfile } = useMyStore();
+  
   return useMutation({
     mutationFn: (data: LoginRequestDTO) => login(data),
     onSuccess: (data) => {
       // 로그인 성공 시 액세스 토큰 설정
       setAccessToken(`Bearer ${data.access_token}`);
+      
+      // 사용자 정보를 store에 저장
+      if (data.data) {
+        updateUserProfile({
+          id: data.data.user_id,
+          name: data.data.user_name,
+          email: data.data.user_email,
+          grade: 'BRONZE', // 기본값
+          progressToNextGrade: 0,
+          coupons: 0,
+          participatedMatches: 0,
+          writtenReviews: 0,
+          preferredSports: [],
+        });
+      }
     },
     onError: (error) => {
       console.error('로그인 실패:', error);
@@ -29,11 +47,15 @@ export const useLogin = () => {
 
 // POST /auth/logout - 로그아웃 훅
 export const useLogout = () => {
+  const { resetUserProfile } = useMyStore();
+  
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
       // 로그아웃 성공 시 액세스 토큰 제거
       setAccessToken(null);
+      // 사용자 정보 초기화
+      resetUserProfile();
     },
     onError: (error) => {
       console.error('로그아웃 실패:', error);

--- a/moigoFront/src/hooks/useChangePassword.ts
+++ b/moigoFront/src/hooks/useChangePassword.ts
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'react';
+import { useChangePassword as useChangePasswordMutation } from './queries/useUserQueries';
+import { useAuthStore } from '@/store/authStore';
+
+interface ChangePasswordForm {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+interface ChangePasswordErrors {
+  currentPassword?: string;
+  newPassword?: string;
+  confirmPassword?: string;
+}
+
+export const useChangePassword = () => {
+  const [form, setForm] = useState<ChangePasswordForm>({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  
+  const [errors, setErrors] = useState<ChangePasswordErrors>({});
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+  const [toastType, setToastType] = useState<'success' | 'error'>('success');
+  
+  const { validatePassword } = useAuthStore();
+  const changePasswordMutation = useChangePasswordMutation();
+
+  // 폼 유효성 검사
+  const validateForm = (): boolean => {
+    const newErrors: ChangePasswordErrors = {};
+    
+    if (!form.currentPassword) {
+      newErrors.currentPassword = '현재 비밀번호를 입력해주세요.';
+    }
+    
+    if (!form.newPassword) {
+      newErrors.newPassword = '새 비밀번호를 입력해주세요.';
+    } else {
+      const validation = validatePassword(form.newPassword);
+      if (!validation.isValid) {
+        newErrors.newPassword = validation.errors[0];
+      }
+    }
+    
+    if (!form.confirmPassword) {
+      newErrors.confirmPassword = '새 비밀번호 확인을 입력해주세요.';
+    } else if (form.newPassword !== form.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // 폼이 유효한지 확인
+  const isFormValid = (): boolean => {
+    const newErrors: ChangePasswordErrors = {};
+    
+    if (!form.currentPassword) {
+      newErrors.currentPassword = '현재 비밀번호를 입력해주세요.';
+    }
+    
+    if (!form.newPassword) {
+      newErrors.newPassword = '새 비밀번호를 입력해주세요.';
+    } else {
+      const validation = validatePassword(form.newPassword);
+      if (!validation.isValid) {
+        newErrors.newPassword = validation.errors[0];
+      }
+    }
+    
+    if (!form.confirmPassword) {
+      newErrors.confirmPassword = '새 비밀번호 확인을 입력해주세요.';
+    } else if (form.newPassword !== form.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+    
+    return form.currentPassword.length > 0 && 
+           form.newPassword.length > 0 && 
+           form.confirmPassword.length > 0 && 
+           Object.keys(newErrors).length === 0;
+  };
+
+  // 입력값 변경 핸들러
+  const handleInputChange = (field: keyof ChangePasswordForm, value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  // 비밀번호 변경 제출
+  const handleSubmit = async () => {
+    if (!validateForm()) return;
+    
+    try {
+      const result = await changePasswordMutation.mutateAsync({
+        old_password: form.currentPassword,
+        new_password: form.newPassword,
+      });
+      
+      if (result.success) {
+        setToastMessage('저장되었습니다');
+        setToastType('success');
+        setShowToast(true);
+        
+        // 폼 초기화
+        setForm({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+        });
+        setErrors({});
+        
+        return { success: true };
+      } else {
+        // API에서 success: false로 응답한 경우
+        let errorMessage = '비밀번호 변경에 실패했습니다';
+        
+        if (result.errorCode === 'WRONG_PASSWORD') {
+          errorMessage = '현재 비밀번호가 올바르지 않습니다';
+          setErrors(prev => ({ ...prev, currentPassword: errorMessage }));
+        }
+        
+        setToastMessage(errorMessage);
+        setToastType('error');
+        setShowToast(true);
+        
+        return { success: false, error: errorMessage };
+      }
+    } catch (error: any) {
+      console.error('비밀번호 변경 실패:', error);
+      
+      let errorMessage = '비밀번호 변경에 실패했습니다';
+      
+      if (error?.response?.data?.errorCode === 'WRONG_PASSWORD') {
+        errorMessage = '현재 비밀번호가 올바르지 않습니다';
+        setErrors(prev => ({ ...prev, currentPassword: errorMessage }));
+      }
+      
+      setToastMessage(errorMessage);
+      setToastType('error');
+      setShowToast(true);
+      
+      return { success: false, error: errorMessage };
+    }
+  };
+
+  // 입력값 변경 시 실시간 유효성 검사
+  useEffect(() => {
+    const newErrors: ChangePasswordErrors = {};
+    
+    if (form.currentPassword && !form.currentPassword.trim()) {
+      newErrors.currentPassword = '현재 비밀번호를 입력해주세요.';
+    }
+    
+    if (form.newPassword) {
+      const validation = validatePassword(form.newPassword);
+      if (!validation.isValid) {
+        newErrors.newPassword = validation.errors[0];
+      }
+    }
+    
+    if (form.confirmPassword && form.newPassword !== form.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+    
+    setErrors(newErrors);
+  }, [form.currentPassword, form.newPassword, form.confirmPassword]);
+
+  return {
+    form,
+    errors,
+    showToast,
+    toastMessage,
+    toastType,
+    isLoading: changePasswordMutation.isPending,
+    handleInputChange,
+    handleSubmit,
+    isFormValid,
+    setShowToast,
+  };
+}; 

--- a/moigoFront/src/hooks/useMyScreen.ts
+++ b/moigoFront/src/hooks/useMyScreen.ts
@@ -41,6 +41,7 @@ export function useMyScreen() {
         id: myInfo.data.user_id,
         name: myInfo.data.user_name,
         email: myInfo.data.user_email,
+        phone: myInfo.data.user_phone_number || '',
         gender: (myInfo.data.user_gender === 1 ? 'male' : 'female') as 'male' | 'female',
         profileImage: myInfo.data.user_thumbnail || undefined,
         grade: 'BRONZE' as const,

--- a/moigoFront/src/hooks/useParticipatedMatches.ts
+++ b/moigoFront/src/hooks/useParticipatedMatches.ts
@@ -1,18 +1,53 @@
+import React from 'react';
 import { useParticipatedMatchesStore } from '@/store/participatedMatchesStore';
+import { useGetMatchingHistory } from '@/hooks/queries/useUserQueries';
 import { Alert } from 'react-native';
 
 export function useParticipatedMatches() {
+  // API에서 매칭 이력 가져오기
+  const { data: matchingHistory, isLoading: isApiLoading, error } = useGetMatchingHistory();
+  
   const {
-    matches,
     selectedCategory,
     selectedSort,
-    isLoading,
+    isLoading: isStoreLoading,
     getFilteredAndSortedMatches,
     setCategory,
     setSort,
     writeReview,
     setLoading,
+    updateMatches,
   } = useParticipatedMatchesStore();
+
+  // API 데이터를 store에 업데이트
+  React.useEffect(() => {
+    if (matchingHistory?.data) {
+      console.log('매칭 이력 API 응답:', matchingHistory.data);
+      
+      // API 응답을 store 형식으로 변환
+      const transformedMatches = matchingHistory.data.map((item) => {
+        const date = new Date(item.reservation_start_time);
+        return {
+          id: item.reservation_id.toString(),
+          title: item.reservation_match,
+          date: date,
+          time: date.toLocaleTimeString('ko-KR', { 
+            hour: '2-digit', 
+            minute: '2-digit',
+            hour12: true 
+          }),
+          location: item.store_name,
+          status: item.status,
+          category: '축구', // API에서 카테고리 정보가 없으므로 기본값 사용
+          participants: 0, // API에서 참가자 수 정보가 없으므로 기본값 사용
+          maxParticipants: 0, // API에서 최대 참가자 수 정보가 없으므로 기본값 사용
+          hasReview: false, // 기본값
+        };
+      });
+      
+      updateMatches(transformedMatches);
+    }
+  }, [matchingHistory, updateMatches]);
 
   // 카테고리 변경
   const handleCategoryChange = (category: string) => {
@@ -40,11 +75,11 @@ export function useParticipatedMatches() {
 
   return {
     // 상태
-    matches,
     selectedCategory,
     selectedSort,
-    isLoading,
+    isLoading: isApiLoading || isStoreLoading,
     filteredAndSortedMatches: getFilteredAndSortedMatches(),
+    error,
     
     // 액션
     handleCategoryChange,

--- a/moigoFront/src/hooks/useProfile.ts
+++ b/moigoFront/src/hooks/useProfile.ts
@@ -4,6 +4,7 @@ import type { ProfileFormData } from '@/types/profile';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '@/types/RootStackParamList';
+import { updateProfile } from '@/apis/users';
 
 export function useProfile() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -24,11 +25,11 @@ export function useProfile() {
     if (userProfile) {
       setFormData({
         name: userProfile.name,
-        phone: userProfile.phone,
+        phone: userProfile.phone || '',
         email: userProfile.email,
-        birthDate: userProfile.birthDate,
+        birthDate: userProfile.birthDate || '',
         gender: userProfile.gender,
-        bio: userProfile.bio,
+        bio: userProfile.bio || '',
       });
     }
   }, [userProfile]);
@@ -44,11 +45,11 @@ export function useProfile() {
     if (userProfile) {
       setFormData({
         name: userProfile.name,
-        phone: userProfile.phone,
+        phone: userProfile.phone || '',
         email: userProfile.email,
-        birthDate: userProfile.birthDate,
+        birthDate: userProfile.birthDate || '',
         gender: userProfile.gender,
-        bio: userProfile.bio,
+        bio: userProfile.bio || '',
       });
     }
   };
@@ -67,8 +68,16 @@ export function useProfile() {
 
     setLoading(true);
     try {
-      // API 호출 로직 (나중에 구현)
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // API 호출
+      const updateData = {
+        user_name: formData.name,
+        user_region: userProfile.region || '서울',
+        user_phone_number: formData.phone,
+        user_thumbnail: userProfile.profileImage || undefined,
+      };
+
+      console.log('프로필 업데이트 요청:', updateData);
+      await updateProfile(updateData);
 
       // myStore 업데이트
       updateUserProfile({
@@ -82,7 +91,6 @@ export function useProfile() {
 
       console.log('프로필 저장 완료');
       setIsModalOpen(true);
-      // navigation.navigate('Main', { screen: 'My' });
       setIsEditing(false);
     } catch (error) {
       console.error('프로필 저장 실패:', error);

--- a/moigoFront/src/screens/Mypage/Profile.tsx
+++ b/moigoFront/src/screens/Mypage/Profile.tsx
@@ -40,13 +40,13 @@ export default function Profile() {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-white" edges={['left', 'right', 'bottom']}>
       <CheckModal visible={isModalOpen} title={''} onClose={handleModalClick}>
-        <View className="flex-col items-center gap-4 mb-8">
-          <View className="items-center justify-center w-20 h-20 rounded-full bg-mainOrange">
+        <View className="flex-col gap-4 items-center mb-8">
+          <View className="justify-center items-center w-20 h-20 rounded-full bg-mainOrange">
             <Feather name="check" size={30} color="white" />
           </View>
-          <Text className="text-2xl font-bold ">저장완료</Text>
+          <Text className="text-2xl font-bold">저장완료</Text>
           <Text className="text-mainDarkGray">개인정보가 성공적으로 수정되었습니다.</Text>
         </View>
         <PrimaryButton
@@ -55,7 +55,7 @@ export default function Profile() {
           disabled={isLoading || !isFormValid}
         />
       </CheckModal>
-      <ScrollView className="flex-1">
+      <ScrollView className="flex-1 pt-8">
         {/* 프로필 이미지 */}
         <ProfileImage imageUri={profileData.profileImage} onImageChange={handleImagePress} />
 

--- a/moigoFront/src/screens/ParticipatedMatches/ParticipatedMatchesScreen.tsx
+++ b/moigoFront/src/screens/ParticipatedMatches/ParticipatedMatchesScreen.tsx
@@ -52,7 +52,7 @@ export default function ParticipatedMatchesScreen() {
 
           {/* 빈 상태 */}
           {filteredAndSortedMatches.length === 0 && (
-            <View className="items-center justify-center flex-1 py-20">
+            <View className="flex-1 justify-center items-center py-20">
               <Text className="mt-4 text-lg font-medium text-mainGrayText">
                 참여한 매칭이 없습니다
               </Text>

--- a/moigoFront/src/store/myStore.ts
+++ b/moigoFront/src/store/myStore.ts
@@ -9,6 +9,11 @@ interface UserProfile {
   id: string;
   name: string;
   email: string;
+  gender: 'male' | 'female';
+  phone?: string;
+  birthDate?: string;
+  bio?: string;
+  region?: string;
   profileImage?: string;
   grade: UserGrade;
   progressToNextGrade: number;
@@ -33,6 +38,7 @@ interface MyState {
 
   // 액션
   updateUserProfile: (profile: Partial<UserProfile>) => void;
+  updateProfileImage: (imageUri: string) => void;
   initializeUserProfile: (authUser: { id: string; email: string }) => void;
   resetUserProfile: () => void;
   toggleNotifications: () => void;
@@ -54,6 +60,7 @@ const createUserProfileFromAuth = (authUser: { id: string; email: string }): Use
     id: authUser.id,
     name: name,
     email: authUser.email,
+    gender: 'male', // 기본값
     profileImage: undefined,
     grade: 'BRONZE',
     progressToNextGrade: 0,
@@ -74,7 +81,14 @@ export const useMyStore = create<MyState>((set, get) => ({
   // 사용자 프로필 업데이트
   updateUserProfile: (profile: Partial<UserProfile>) => {
     set((state) => ({
-      userProfile: state.userProfile ? { ...state.userProfile, ...profile } : null,
+      userProfile: state.userProfile ? { ...state.userProfile, ...profile } : profile as UserProfile,
+    }));
+  },
+
+  // 프로필 이미지 업데이트
+  updateProfileImage: (imageUri: string) => {
+    set((state) => ({
+      userProfile: state.userProfile ? { ...state.userProfile, profileImage: imageUri } : null,
     }));
   },
 

--- a/moigoFront/src/store/participatedMatchesStore.ts
+++ b/moigoFront/src/store/participatedMatchesStore.ts
@@ -14,6 +14,7 @@ interface ParticipatedMatchesState {
   setSort: (sort: SortOption) => void;
   writeReview: (matchId: string) => void;
   setLoading: (loading: boolean) => void;
+  updateMatches: (matches: ParticipatedMatch[]) => void;
   
   // 계산된 값
   getFilteredAndSortedMatches: () => ParticipatedMatch[];
@@ -50,6 +51,11 @@ export const useParticipatedMatchesStore = create<ParticipatedMatchesState>((set
     set({ isLoading: loading });
   },
   
+  // 매칭 목록 업데이트
+  updateMatches: (matches: ParticipatedMatch[]) => {
+    set({ matches });
+  },
+  
   // 필터링 및 정렬된 매칭 목록
   getFilteredAndSortedMatches: () => {
     const { matches, selectedCategory, selectedSort } = get();
@@ -62,32 +68,42 @@ export const useParticipatedMatchesStore = create<ParticipatedMatchesState>((set
     
     // 정렬
     const sorted = [...filtered].sort((a, b) => {
-      // 날짜 파싱 함수
-      const parseDate = (dateStr: string, timeStr: string) => {
-        // "2024년 7월 10일" -> "2024-07-10"
-        const dateMatch = dateStr.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/);
-        if (!dateMatch) return new Date(0);
+      // 날짜 파싱 함수 - API 데이터와 mock 데이터 모두 지원
+      const parseDate = (match: ParticipatedMatch) => {
+        // API 데이터인 경우 (date가 Date 객체)
+        if (match.date instanceof Date) {
+          return match.date;
+        }
         
-        const year = parseInt(dateMatch[1]);
-        const month = parseInt(dateMatch[2]) - 1; // 월은 0부터 시작
-        const day = parseInt(dateMatch[3]);
+        // Mock 데이터인 경우 (date가 문자열)
+        if (typeof match.date === 'string') {
+          // "2024년 7월 10일" -> "2024-07-10"
+          const dateMatch = match.date.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/);
+          if (!dateMatch) return new Date(0);
+          
+          const year = parseInt(dateMatch[1]);
+          const month = parseInt(dateMatch[2]) - 1; // 월은 0부터 시작
+          const day = parseInt(dateMatch[3]);
+          
+          // "오후 6:30" -> 18:30
+          const timeMatch = match.time?.match(/(오전|오후)\s*(\d{1,2}):(\d{2})/);
+          if (!timeMatch) return new Date(year, month, day);
+          
+          const period = timeMatch[1];
+          let hour = parseInt(timeMatch[2]);
+          const minute = parseInt(timeMatch[3]);
+          
+          if (period === '오후' && hour !== 12) hour += 12;
+          if (period === '오전' && hour === 12) hour = 0;
+          
+          return new Date(year, month, day, hour, minute);
+        }
         
-        // "오후 6:30" -> 18:30
-        const timeMatch = timeStr.match(/(오전|오후)\s*(\d{1,2}):(\d{2})/);
-        if (!timeMatch) return new Date(year, month, day);
-        
-        const period = timeMatch[1];
-        let hour = parseInt(timeMatch[2]);
-        const minute = parseInt(timeMatch[3]);
-        
-        if (period === '오후' && hour !== 12) hour += 12;
-        if (period === '오전' && hour === 12) hour = 0;
-        
-        return new Date(year, month, day, hour, minute);
+        return new Date(0);
       };
       
-      const dateA = parseDate(a.date, a.time);
-      const dateB = parseDate(b.date, b.time);
+      const dateA = parseDate(a);
+      const dateB = parseDate(b);
       
       if (selectedSort === '최신순') {
         return dateB.getTime() - dateA.getTime();

--- a/moigoFront/src/types/DTO/auth.ts
+++ b/moigoFront/src/types/DTO/auth.ts
@@ -23,8 +23,15 @@ export interface LoginRequestDTO {
 export interface LoginResponseDTO {
   success: boolean;
   access_token: string;
-  user_id: string;
-  user_name: string;
+  data: {
+    user_id: string;
+    user_name: string;
+    user_email: string;
+    user_region: string;
+    user_gender: number;
+    user_phone_number: string;
+    user_thumbnail: string | null;
+  };
 }
 
 // 인증 에러 응답 DTO

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -54,7 +54,8 @@ export interface ChangePasswordRequestDTO {
 // 비밀번호 변경 응답 DTO
 export interface ChangePasswordResponseDTO {
   success: boolean;
-  message: string;
+  message?: string;
+  errorCode?: string;
 }
 
 // 매칭 이력 DTO

--- a/moigoFront/src/types/reservation.ts
+++ b/moigoFront/src/types/reservation.ts
@@ -11,11 +11,13 @@ export interface Reservation {
 export interface ParticipatedMatch {
   id: string;
   title: string;
-  date: string;
-  time: string;
+  date: string | Date;
+  time?: string;
   location: string;
   participants: number;
+  maxParticipants: number;
   category: '축구' | '야구' | '농구' | '격투기' | '게임';
+  status: string;
   hasReview: boolean;
 }
 


### PR DESCRIPTION
## 변경사항

### ✨ 새로운 기능
- **비밀번호 변경 커스텀 훅 추가** (`useChangePassword.ts`)
  - 폼 상태 관리 및 실시간 유효성 검사
  - API 호출 및 에러 처리 로직 분리
  - 토스트 메시지 관리

### 버그 수정
- **마이페이지 전화번호 표시 문제 해결**
  - `users/me` API 응답의 `user_phone_number` 필드를 `UserProfile.phone`으로 매핑
  - 프로필 수정 화면에서 전화번호가 빈칸으로 표시되던 문제 해결

### 개선사항
- **API 응답 타입 업데이트** (`ChangePasswordResponseDTO`)
  - 비밀번호 변경 API 응답에 `errorCode` 필드 추가
  - `WRONG_PASSWORD` 에러 코드 처리 로직 추가

## 상세 변경사항

### 파일 변경
- `src/hooks/useChangePassword.ts` (신규)
- `src/screens/Password/ChangePasswordScreen.tsx`
- `src/hooks/useMyScreen.ts`
- `src/types/DTO/users.ts`

### 주요 개선점
1. **컴포넌트 로직 분리**: `ChangePasswordScreen`에서 상태관리 로직을 커스텀 훅으로 분리
2. **재사용성 향상**: 비밀번호 변경 로직을 다른 컴포넌트에서도 재사용 가능
3. **에러 처리 개선**: API 응답에 따른 세밀한 에러 처리
4. **데이터 매핑 수정**: API 응답과 프론트엔드 데이터 구조 간 매핑 문제 해결

## 🧪 테스트
- [x] 비밀번호 변경 기능 정상 동작 확인
- [x] 마이페이지 전화번호 표시 확인
- [x] 에러 케이스 처리 확인

## 📋 체크리스트
- [x] 코드 리뷰 완료
- [x] 테스트 완료
- [x] 문서 업데이트