### PR TITLE
Front/feat business setting

### DIFF
--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -57,7 +57,7 @@ export const updateProfile = async (
   return response.data;
 };
 
-// PUT /users/me/password - 비밀번호 변경
+// PUT /users/me/password 또는 PUT /stores/me/password - 비밀번호 변경
 export const changePassword = async (
   data: ChangePasswordRequestDTO,
   endpoint?: string
@@ -282,6 +282,24 @@ export const updateStoreDetailInfo = async (
 // 예약 설정 조회
 export const getReservationSettings = async () => {
   const response = await apiClient.get('/stores/me/settings/reservation');
+  return response.data;
+};
+
+// 회원 탈퇴 관련 API
+
+// 일반 사용자 회원 탈퇴 - DELETE /api/v1/users/me
+export const deleteUser = async (): Promise<{ success: boolean; message: string }> => {
+  console.log('🌐 [API] deleteUser 호출: DELETE /users/me');
+  const response = await apiClient.delete('/users/me');
+  console.log('✅ [API] deleteUser 성공:', response.data);
+  return response.data;
+};
+
+// 사장님 회원 탈퇴 - DELETE /api/v1/stores/me
+export const deleteStore = async (): Promise<{ success: boolean; message: string }> => {
+  console.log('🌐 [API] deleteStore 호출: DELETE /stores/me');
+  const response = await apiClient.delete('/stores/me');
+  console.log('✅ [API] deleteStore 성공:', response.data);
   return response.data;
 };
 

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -21,6 +21,7 @@ import type {
   StoreBasicInfoResponseDTO,
   StoreDetailInfoRequestDTO,
   StoreDetailInfoResponseDTO,
+  BusinessHoursDTO,
 } from '../../types/DTO/users';
 import type { GetUserProfileResponseDTO } from '../../types/DTO/chat';
 
@@ -239,15 +240,11 @@ export const updateReservationSettings = async (
   return response.data;
 };
 
-// 가게 상세 정보 관련 API
-
-// 매장 상세 정보 수정 - PUT /api/v1/stores/me/details
-export const updateStoreDetailInfo = async (
-  data: StoreDetailInfoRequestDTO
-): Promise<StoreDetailInfoResponseDTO> => {
-
-  const response = await apiClient.put<StoreDetailInfoResponseDTO>('/stores/me/details', data);
-
+// 영업 시간 설정 수정
+export const updateBusinessHours = async (businessHours: BusinessHoursDTO[]) => {
+  const response = await apiClient.put('/stores/me/settings/reservation', {
+    available_times: businessHours
+  });
   return response.data;
 };
 
@@ -268,5 +265,17 @@ export const addSportsCategory = async (categoryName: string) => {
 // 스포츠 카테고리 삭제
 export const deleteSportsCategory = async (categoryName: string) => {
   const response = await apiClient.delete(`/stores/me/sports-categories/${categoryName}`);
+  return response.data;
+};
+
+// 가게 상세 정보 관련 API
+
+// 매장 상세 정보 수정 - PUT /api/v1/stores/me/details
+export const updateStoreDetailInfo = async (
+  data: StoreDetailInfoRequestDTO
+): Promise<StoreDetailInfoResponseDTO> => {
+
+  const response = await apiClient.put<StoreDetailInfoResponseDTO>('/stores/me/details', data);
+
   return response.data;
 };

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -236,17 +236,16 @@ export const updateReservationSettings = async (
     available_times?: Array<{ day: string; start: string; end: string }>;
   }
 ): Promise<{ success: boolean; message: string }> => {
+  console.log('🌐 [API] updateReservationSettings 호출:', data);
+  console.log('🌐 [API] 요청 URL: /stores/me/settings/reservation');
+  
   const response = await apiClient.put('/stores/me/settings/reservation', data);
+  
+  console.log('🌐 [API] 응답 성공:', response.data);
   return response.data;
 };
 
-// 영업 시간 설정 수정
-export const updateBusinessHours = async (businessHours: BusinessHoursDTO[]) => {
-  const response = await apiClient.put('/stores/me/settings/reservation', {
-    available_times: businessHours
-  });
-  return response.data;
-};
+
 
 // 스포츠 카테고리 조회
 export const getSportsCategories = async () => {

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -279,6 +279,41 @@ export const updateStoreDetailInfo = async (
   return response.data;
 };
 
+// 편의시설 관련 API
+
+// 편의시설 목록 조회 - GET /api/v1/stores/me/facilities
+export const getStoreFacilities = async () => {
+  const response = await apiClient.get('/stores/me/facilities');
+  return response.data;
+};
+
+// 편의시설 추가 - POST /api/v1/stores/me/facilities
+export const addStoreFacility = async (data: { facility_type: string; facility_name: string }) => {
+  const response = await apiClient.post('/stores/me/facilities', data);
+  return response.data;
+};
+
+// 편의시설 수정 - PUT /api/v1/stores/me/facilities/{facility_id}
+export const updateStoreFacility = async (
+  facilityId: number, 
+  data: { facility_type: string; facility_name: string; is_available: boolean }
+) => {
+  const response = await apiClient.put(`/stores/me/facilities/${facilityId}`, data);
+  return response.data;
+};
+
+// 편의시설 삭제 - DELETE /api/v1/stores/me/facilities/{facility_id}
+export const deleteStoreFacility = async (facilityId: number) => {
+  const response = await apiClient.delete(`/stores/me/facilities/${facilityId}`);
+  return response.data;
+};
+
+// 편의시설 사용 가능 여부 토글 - PUT /api/v1/stores/me/facilities/{facility_id}/toggle
+export const toggleStoreFacility = async (facilityId: number) => {
+  const response = await apiClient.put(`/stores/me/facilities/${facilityId}/toggle`);
+  return response.data;
+};
+
 // 예약 설정 조회
 export const getReservationSettings = async () => {
   const response = await apiClient.get('/stores/me/settings/reservation');

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -250,3 +250,23 @@ export const updateStoreDetailInfo = async (
 
   return response.data;
 };
+
+// 스포츠 카테고리 조회
+export const getSportsCategories = async () => {
+  const response = await apiClient.get('/stores/me/sports-categories');
+  return response.data;
+};
+
+// 스포츠 카테고리 추가
+export const addSportsCategory = async (categoryName: string) => {
+  const response = await apiClient.post('/stores/me/sports-categories', {
+    category_name: categoryName
+  });
+  return response.data;
+};
+
+// 스포츠 카테고리 삭제
+export const deleteSportsCategory = async (categoryName: string) => {
+  const response = await apiClient.delete(`/stores/me/sports-categories/${categoryName}`);
+  return response.data;
+};

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -279,3 +279,11 @@ export const updateStoreDetailInfo = async (
 
   return response.data;
 };
+
+// 예약 설정 조회
+export const getReservationSettings = async () => {
+  const response = await apiClient.get('/stores/me/settings/reservation');
+  return response.data;
+};
+
+

--- a/moigoFront/src/apis/users/index.ts
+++ b/moigoFront/src/apis/users/index.ts
@@ -16,6 +16,11 @@ import type {
   ReservationActionResponseDTO,
   MatchesResponseDTO,
   ScheduleResponseDTO,
+  StoreInfoResponseDTO,
+  StoreBasicInfoRequestDTO,
+  StoreBasicInfoResponseDTO,
+  StoreDetailInfoRequestDTO,
+  StoreDetailInfoResponseDTO,
 } from '../../types/DTO/users';
 import type { GetUserProfileResponseDTO } from '../../types/DTO/chat';
 
@@ -164,10 +169,8 @@ export const getMatches = async (params?: {
   }
   
   const url = `/matches${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
-  console.log('🎯 [API] getMatches 호출:', url);
   
   const response = await apiClient.get<MatchesResponseDTO>(url);
-  console.log('✅ [API] getMatches 성공:', response.data);
   return response.data;
 };
 
@@ -190,9 +193,60 @@ export const getStoreSchedule = async (params?: {
   }
   
   const url = `/stores/me/reservations${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
-  console.log('📅 [API] getStoreSchedule 호출:', url);
   
   const response = await apiClient.get<ScheduleResponseDTO>(url);
-  console.log('✅ [API] getStoreSchedule 성공:', response.data);
+  return response.data;
+};
+
+// 가게 정보 관련 API
+
+// 매장 정보 조회 - GET /api/v1/stores/me
+export const getStoreInfo = async (): Promise<StoreInfoResponseDTO> => {
+  const response = await apiClient.get<StoreInfoResponseDTO>('/stores/me');
+  return response.data;
+};
+
+// 매장 기본 정보 수정 - PUT /api/v1/stores/me/basic-info
+export const updateStoreBasicInfo = async (
+  data: StoreBasicInfoRequestDTO
+): Promise<StoreBasicInfoResponseDTO> => {
+  const response = await apiClient.put<StoreBasicInfoResponseDTO>('/stores/me/basic-info', data);
+  return response.data;
+};
+
+// 알림 설정 업데이트 - PUT /api/v1/stores/me/settings/notification
+export const updateNotificationSettings = async (
+  data: {
+    reservation_alerts: boolean;
+    payment_alerts: boolean;
+    system_alerts: boolean;
+    marketing_alerts: boolean;
+  }
+): Promise<{ success: boolean; message: string }> => {
+  const response = await apiClient.put('/stores/me/settings/notification', data);
+  return response.data;
+};
+
+// 예약 설정 업데이트 - PUT /api/v1/stores/me/settings/reservation
+export const updateReservationSettings = async (
+  data: {
+    deposit_amount?: number;
+    min_participants?: number;
+    available_times?: Array<{ day: string; start: string; end: string }>;
+  }
+): Promise<{ success: boolean; message: string }> => {
+  const response = await apiClient.put('/stores/me/settings/reservation', data);
+  return response.data;
+};
+
+// 가게 상세 정보 관련 API
+
+// 매장 상세 정보 수정 - PUT /api/v1/stores/me/details
+export const updateStoreDetailInfo = async (
+  data: StoreDetailInfoRequestDTO
+): Promise<StoreDetailInfoResponseDTO> => {
+
+  const response = await apiClient.put<StoreDetailInfoResponseDTO>('/stores/me/details', data);
+
   return response.data;
 };

--- a/moigoFront/src/components/business/MinReservationModal.tsx
+++ b/moigoFront/src/components/business/MinReservationModal.tsx
@@ -19,6 +19,12 @@ export default function MinReservationModal({
 }: MinReservationModalProps) {
   const [minCapacity, setMinCapacity] = useState(currentMinCapacity);
 
+  // currentMinCapacity가 변경될 때마다 상태 업데이트
+  React.useEffect(() => {
+    console.log('🔍 [모달] 최소 인원수 변경됨:', currentMinCapacity);
+    setMinCapacity(currentMinCapacity);
+  }, [currentMinCapacity]);
+
   const increaseCapacity = () => {
     if (minCapacity < 10) {
       setMinCapacity(prev => prev + 1);
@@ -32,6 +38,7 @@ export default function MinReservationModal({
   };
 
   const handleSave = () => {
+    console.log('💾 [모달] 최소 인원수 저장:', minCapacity);
     onSave(minCapacity);
     onClose();
   };
@@ -61,7 +68,7 @@ export default function MinReservationModal({
           onPress={increaseCapacity}
           activeOpacity={0.7}
         >
-          <Feather name="plus" size={24} color={COLORS.mainDarkGray} />1
+          <Feather name="plus" size={24} color={COLORS.mainDarkGray} />
         </TouchableOpacity>
       </View>
 

--- a/moigoFront/src/components/common/Toast.tsx
+++ b/moigoFront/src/components/common/Toast.tsx
@@ -17,11 +17,11 @@ export default function Toast({
   message, 
   type = 'success', 
   onHide, 
-  duration = 3000,
+  duration = 2000,
   className
 }: ToastProps) {
   const fadeAnim = new Animated.Value(0);
-  const slideAnim = new Animated.Value(-100);
+  const slideAnim = new Animated.Value(100);
 
   useEffect(() => {
     if (visible) {
@@ -29,12 +29,12 @@ export default function Toast({
       Animated.parallel([
         Animated.timing(fadeAnim, {
           toValue: 1,
-          duration: 300,
+          duration: 200,
           useNativeDriver: true,
         }),
         Animated.timing(slideAnim, {
           toValue: 0,
-          duration: 300,
+          duration: 200,
           useNativeDriver: true,
         }),
       ]).start();
@@ -52,12 +52,12 @@ export default function Toast({
     Animated.parallel([
       Animated.timing(fadeAnim, {
         toValue: 0,
-        duration: 300,
+        duration: 200,
         useNativeDriver: true,
       }),
       Animated.timing(slideAnim, {
-        toValue: -100,
-        duration: 300,
+        toValue: 100,
+        duration: 200,
         useNativeDriver: true,
       }),
     ]).start(() => {
@@ -115,12 +115,6 @@ export default function Toast({
         <Text className="flex-1 text-base font-medium text-white">
           {message}
         </Text>
-        {/* <Feather 
-          name="x" 
-          size={20} 
-          color="white" 
-          onPress={hideToast}
-        /> */}
       </View>
     </Animated.View>
   );

--- a/moigoFront/src/hooks/queries/index.ts
+++ b/moigoFront/src/hooks/queries/index.ts
@@ -39,4 +39,13 @@ export { useHomeScreen } from '../useHomeScreen';
 export {
   useMatches,
   useStoreSchedule,
+} from './useUserQueries';
+
+// 가게 정보 관련 훅
+export {
+  useStoreInfo,
+  useUpdateStoreBasicInfo,
+  useUpdateNotificationSettings,
+  useUpdateReservationSettings,
+  useUpdateStoreDetailInfo,
 } from './useUserQueries'; 

--- a/moigoFront/src/hooks/queries/index.ts
+++ b/moigoFront/src/hooks/queries/index.ts
@@ -33,7 +33,11 @@ export { useStoreDashboard } from '../useHomeScreen';
 export { useStoreReservations } from '../useHomeScreen';
 export { useAcceptReservation } from '../useHomeScreen';
 export { useRejectReservation } from '../useHomeScreen';
+export { useBusinessHomeScreen } from '../useHomeScreen';
 export { useHomeScreen } from '../useHomeScreen';
+
+// 회원 탈퇴
+export { useDeleteAccount } from './useUserQueries';
 
 // 일정 관련 훅
 export {

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -9,11 +9,18 @@ import {
   getReservationHistory,
   getMatches,
   getStoreSchedule,
+  getStoreInfo,
+  updateStoreBasicInfo,
+  updateNotificationSettings,
+  updateReservationSettings,
+  updateStoreDetailInfo,
 } from '../../apis/users';
 import type {
   UpdateProfileRequestDTO,
   ChangePasswordRequestDTO,
   UpdateUserSettingsRequestDTO,
+  StoreBasicInfoRequestDTO,
+  StoreDetailInfoRequestDTO,
 } from '../../types/DTO/users';
 
 // GET /users/me - 마이페이지 정보 조회 훅
@@ -142,6 +149,92 @@ export const useUpdateUserSettings = () => {
     },
     onError: (error) => {
       console.error('사용자 설정 변경 실패:', error);
+    },
+  });
+};
+
+// 가게 정보 관련 훅
+export const useStoreInfo = () => {
+  return useQuery({
+    queryKey: ['storeInfo'],
+    queryFn: () => getStoreInfo(),
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+};
+
+export const useUpdateStoreBasicInfo = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: (data: StoreBasicInfoRequestDTO) => updateStoreBasicInfo(data),
+    onSuccess: () => {
+      // 매장 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+      console.log('✅ [훅] 매장 기본 정보 수정 성공');
+    },
+    onError: (error) => {
+      console.error('❌ [훅] 매장 기본 정보 수정 실패:', error);
+    },
+  });
+}; 
+
+// 알림 설정 업데이트 훅
+export const useUpdateNotificationSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: {
+      reservation_alerts: boolean;
+      payment_alerts: boolean;
+      system_alerts: boolean;
+      marketing_alerts: boolean;
+    }) => updateNotificationSettings(data),
+    onSuccess: () => {
+      // 매장 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+      console.log('✅ [훅] 알림 설정 업데이트 성공');
+    },
+    onError: (error) => {
+      console.error('❌ [훅] 알림 설정 업데이트 실패:', error);
+    },
+  });
+};
+
+// 예약 설정 업데이트 훅
+export const useUpdateReservationSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: {
+      deposit_amount?: number;
+      min_participants?: number;
+      available_times?: Array<{ day: string; start: string; end: string }>;
+    }) => updateReservationSettings(data),
+    onSuccess: () => {
+      // 매장 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+      console.log('✅ [훅] 예약 설정 업데이트 성공');
+    },
+    onError: (error) => {
+      console.error('❌ [훅] 예약 설정 업데이트 실패:', error);
+    },
+  });
+}; 
+
+// 가게 상세 정보 수정 훅
+export const useUpdateStoreDetailInfo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: StoreDetailInfoRequestDTO) => updateStoreDetailInfo(data),
+    onSuccess: () => {
+      // 매장 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+      console.log('✅ [훅] 매장 상세 정보 수정 성공');
+    },
+    onError: (error) => {
+      console.error('❌ [훅] 매장 상세 정보 수정 실패:', error);
     },
   });
 }; 

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -17,6 +17,7 @@ import {
   deleteSportsCategory,
   addSportsCategory,
   getSportsCategories,
+  updateBusinessHours,
 } from '../../apis/users';
 import type {
   UpdateProfileRequestDTO,
@@ -238,6 +239,22 @@ export const useUpdateStoreDetailInfo = () => {
     },
     onError: (error) => {
       console.error('❌ [훅] 매장 상세 정보 수정 실패:', error);
+    },
+  });
+}; 
+
+// 영업 시간 설정 수정
+export const useUpdateBusinessHours = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateBusinessHours,
+    onSuccess: (data) => {
+      console.log('✅ 영업 시간 설정 수정 성공:', data);
+      // StoreInfo 쿼리 무효화하여 최신 데이터 반영
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+    },
+    onError: (error) => {
+      console.error('❌ 영업 시간 설정 수정 실패:', error);
     },
   });
 }; 

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -14,6 +14,9 @@ import {
   updateNotificationSettings,
   updateReservationSettings,
   updateStoreDetailInfo,
+  deleteSportsCategory,
+  addSportsCategory,
+  getSportsCategories,
 } from '../../apis/users';
 import type {
   UpdateProfileRequestDTO,
@@ -235,6 +238,47 @@ export const useUpdateStoreDetailInfo = () => {
     },
     onError: (error) => {
       console.error('❌ [훅] 매장 상세 정보 수정 실패:', error);
+    },
+  });
+}; 
+
+// 스포츠 카테고리 조회
+export const useSportsCategories = () => {
+  return useQuery({
+    queryKey: ['sportsCategories'],
+    queryFn: getSportsCategories,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+};
+
+// 스포츠 카테고리 추가
+export const useAddSportsCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: addSportsCategory,
+    onSuccess: (data) => {
+      console.log('✅ 스포츠 카테고리 추가 성공:', data);
+      // 스포츠 카테고리 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['sportsCategories'] });
+    },
+    onError: (error) => {
+      console.error('❌ 스포츠 카테고리 추가 실패:', error);
+    },
+  });
+};
+
+// 스포츠 카테고리 삭제
+export const useDeleteSportsCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteSportsCategory,
+    onSuccess: (data) => {
+      console.log('✅ 스포츠 카테고리 삭제 성공:', data);
+      // 스포츠 카테고리 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['sportsCategories'] });
+    },
+    onError: (error) => {
+      console.error('❌ 스포츠 카테고리 삭제 실패:', error);
     },
   });
 }; 

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -19,6 +19,11 @@ import {
   addSportsCategory,
   getSportsCategories,
   getReservationSettings,
+  getStoreFacilities,
+  addStoreFacility,
+  updateStoreFacility,
+  deleteStoreFacility,
+  toggleStoreFacility,
 } from '../../apis/users';
 import { deleteUser, deleteStore } from '../../apis/users';
 import type {
@@ -298,15 +303,114 @@ export const useUpdateStoreDetailInfo = () => {
       if (user?.userType !== 'business') {
         throw new Error('사장님 계정으로만 접근 가능합니다.');
       }
+      console.log('🏪 [훅] 매장 상세 정보 수정 요청:', data);
+      console.log('🏪 [훅] 편의시설 데이터 확인:', data.facilities);
       return updateStoreDetailInfo(data);
     },
-    onSuccess: () => {
+    onSuccess: (response) => {
       // 매장 정보 캐시 무효화
       queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
-      console.log('✅ [훅] 매장 상세 정보 수정 성공');
+      console.log('✅ [훅] 매장 상세 정보 수정 성공:', response);
+      
+      // 캐시 무효화 후 즉시 새로고침
+      queryClient.refetchQueries({ queryKey: ['storeInfo'] });
     },
     onError: (error) => {
       console.error('❌ [훅] 매장 상세 정보 수정 실패:', error);
+    },
+  });
+};
+
+// 편의시설 관련 훅들
+
+// 편의시설 목록 조회 훅
+export const useStoreFacilities = () => {
+  const { user } = useAuthStore();
+  
+  return useQuery({
+    queryKey: ['storeFacilities'],
+    queryFn: () => getStoreFacilities(),
+    enabled: user?.userType === 'business',
+    staleTime: 5 * 60 * 1000, // 5분
+    gcTime: 10 * 60 * 1000, // 10분
+  });
+};
+
+// 편의시설 추가 훅
+export const useAddStoreFacility = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+
+  return useMutation({
+    mutationFn: (data: { facility_type: string; facility_name: string }) => {
+      if (user?.userType !== 'business') {
+        throw new Error('사장님 계정으로만 접근 가능합니다.');
+      }
+      return addStoreFacility(data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeFacilities'] });
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+    },
+  });
+};
+
+// 편의시설 수정 훅
+export const useUpdateStoreFacility = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+
+  return useMutation({
+    mutationFn: ({ facilityId, data }: { 
+      facilityId: number; 
+      data: { facility_type: string; facility_name: string; is_available: boolean } 
+    }) => {
+      if (user?.userType !== 'business') {
+        throw new Error('사장님 계정으로만 접근 가능합니다.');
+      }
+      return updateStoreFacility(facilityId, data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeFacilities'] });
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+    },
+  });
+};
+
+// 편의시설 삭제 훅
+export const useDeleteStoreFacility = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+
+  return useMutation({
+    mutationFn: (facilityId: number) => {
+      if (user?.userType !== 'business') {
+        throw new Error('사장님 계정으로만 접근 가능합니다.');
+      }
+      return deleteStoreFacility(facilityId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeFacilities'] });
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
+    },
+  });
+};
+
+// 편의시설 토글 훅
+export const useToggleStoreFacility = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+
+  return useMutation({
+    mutationFn: (facilityId: number) => {
+      if (user?.userType !== 'business') {
+        throw new Error('사장님 계정으로만 접근 가능합니다.');
+      }
+      return toggleStoreFacility(facilityId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['storeFacilities'] });
+      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
     },
   });
 }; 

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -18,6 +18,7 @@ import {
   addSportsCategory,
   getSportsCategories,
   updateBusinessHours,
+  getReservationSettings,
 } from '../../apis/users';
 import type {
   UpdateProfileRequestDTO,
@@ -205,23 +206,29 @@ export const useUpdateNotificationSettings = () => {
   });
 };
 
-// 예약 설정 업데이트 훅
+// 예약 설정 조회
+export const useReservationSettings = () => {
+  return useQuery({
+    queryKey: ['reservationSettings'],
+    queryFn: getReservationSettings,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+};
+
+// 예약 설정 수정
 export const useUpdateReservationSettings = () => {
   const queryClient = useQueryClient();
-
   return useMutation({
-    mutationFn: (data: {
-      deposit_amount?: number;
-      min_participants?: number;
-      available_times?: Array<{ day: string; start: string; end: string }>;
-    }) => updateReservationSettings(data),
-    onSuccess: () => {
-      // 매장 정보 캐시 무효화
+    mutationFn: updateReservationSettings,
+    onSuccess: (data) => {
+      console.log('✅ 예약 설정 수정 성공:', data);
+      // 예약 설정 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['reservationSettings'] });
+      // StoreInfo 쿼리도 무효화하여 최신 데이터 반영
       queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
-      console.log('✅ [훅] 예약 설정 업데이트 성공');
     },
     onError: (error) => {
-      console.error('❌ [훅] 예약 설정 업데이트 실패:', error);
+      console.error('❌ 예약 설정 수정 실패:', error);
     },
   });
 }; 

--- a/moigoFront/src/hooks/queries/useUserQueries.ts
+++ b/moigoFront/src/hooks/queries/useUserQueries.ts
@@ -17,7 +17,6 @@ import {
   deleteSportsCategory,
   addSportsCategory,
   getSportsCategories,
-  updateBusinessHours,
   getReservationSettings,
 } from '../../apis/users';
 import type {
@@ -220,15 +219,18 @@ export const useUpdateReservationSettings = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateReservationSettings,
+    onMutate: (data) => {
+      console.log('🚀 [훅] 예약 설정 수정 시작:', data);
+    },
     onSuccess: (data) => {
-      console.log('✅ 예약 설정 수정 성공:', data);
+      console.log('✅ [훅] 예약 설정 수정 성공:', data);
       // 예약 설정 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: ['reservationSettings'] });
       // StoreInfo 쿼리도 무효화하여 최신 데이터 반영
       queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
     },
     onError: (error) => {
-      console.error('❌ 예약 설정 수정 실패:', error);
+      console.error('❌ [훅] 예약 설정 수정 실패:', error);
     },
   });
 }; 
@@ -250,21 +252,7 @@ export const useUpdateStoreDetailInfo = () => {
   });
 }; 
 
-// 영업 시간 설정 수정
-export const useUpdateBusinessHours = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: updateBusinessHours,
-    onSuccess: (data) => {
-      console.log('✅ 영업 시간 설정 수정 성공:', data);
-      // StoreInfo 쿼리 무효화하여 최신 데이터 반영
-      queryClient.invalidateQueries({ queryKey: ['storeInfo'] });
-    },
-    onError: (error) => {
-      console.error('❌ 영업 시간 설정 수정 실패:', error);
-    },
-  });
-}; 
+ 
 
 // 스포츠 카테고리 조회
 export const useSportsCategories = () => {

--- a/moigoFront/src/hooks/useMyInfoSetting.ts
+++ b/moigoFront/src/hooks/useMyInfoSetting.ts
@@ -4,6 +4,7 @@ import { useMyStore } from '@/store/myStore';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '@/types/RootStackParamList';
+import { useDeleteAccount } from './queries/useUserQueries';
 
 export function useMyInfoSetting() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -28,6 +29,7 @@ export function useMyInfoSetting() {
 
   const { logout: authLogout } = useAuthStore();
   const { resetUserProfile } = useMyStore();
+  const deleteAccountMutation = useDeleteAccount();
 
   // 프로필 관리
   const handleProfileManagement = () => {
@@ -125,12 +127,19 @@ export function useMyInfoSetting() {
   };
 
   // 회원탈퇴
-  const handleWithdraw = () => {
-    setLoading(true);
-    // myStore의 사용자 정보 초기화
-    resetUserProfile();
-    authLogout();
-    setLoading(false);
+  const handleWithdraw = async () => {
+    try {
+      console.log('🚀 [회원탈퇴] handleWithdraw 시작');
+      setLoading(true);
+      console.log('🚀 [회원탈퇴] API 호출 시작');
+      await deleteAccountMutation.mutateAsync();
+      console.log('✅ [회원탈퇴] API 호출 성공');
+      // 회원 탈퇴 성공 시 자동으로 로그아웃되고 로그인 전 화면으로 이동됨
+      // useDeleteAccount에서 logout() 호출
+    } catch (error) {
+      console.error('❌ [회원탈퇴] API 호출 실패:', error);
+      setLoading(false);
+    }
   };
 
   return {
@@ -163,5 +172,8 @@ export function useMyInfoSetting() {
     handleSendFeedback,
     handleLogout,
     handleWithdraw,
+    
+    // 회원 탈퇴 상태
+    isDeletingAccount: deleteAccountMutation.isPending,
   };
 }

--- a/moigoFront/src/hooks/useMyScreen.ts
+++ b/moigoFront/src/hooks/useMyScreen.ts
@@ -76,6 +76,7 @@ export function useMyScreen() {
   const handleEditProfile = () => {
     // 프로필 편집 페이지로 이동
     console.log('프로필 편집');
+    navigation.navigate('Profile');
   };
 
   // 비밀번호 편집

--- a/moigoFront/src/hooks/useSettingScreen.ts
+++ b/moigoFront/src/hooks/useSettingScreen.ts
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useStoreInfo, useUpdateStoreBasicInfo } from './queries/useUserQueries';
+import type { StoreBasicInfoRequestDTO } from '../types/DTO/users';
+
+export const useSettingScreen = () => {
+  // 가게 정보 조회
+  const {
+    data: storeInfoData,
+    isLoading: isStoreInfoLoading,
+    error: storeInfoError,
+    refetch: refetchStoreInfo,
+  } = useStoreInfo();
+
+  // 가게 기본 정보 수정
+  const {
+    mutate: updateStoreBasicInfo,
+    isPending: isUpdating,
+    error: updateError,
+    isSuccess: isSaveSuccess,
+    isError: isSaveError,
+  } = useUpdateStoreBasicInfo();
+
+  // 가게 기본 정보 수정 폼 상태
+  const [basicInfoForm, setBasicInfoForm] = useState<StoreBasicInfoRequestDTO>({
+    store_name: '',
+    address_main: '',
+    address_detail: '',
+    phone_number: '',
+    business_reg_no: '',
+    owner_name: '',
+    email: '',
+    bio: '',
+  });
+
+  // 폼 초기화
+  const initializeForm = () => {
+    if (storeInfoData?.data?.store_info) {
+      const storeInfo = storeInfoData.data.store_info;
+      setBasicInfoForm({
+        store_name: storeInfo.store_name || '',
+        address_main: storeInfo.address_main || '',
+        address_detail: storeInfo.address_detail || '',
+        phone_number: storeInfo.phone_number || '',
+        business_reg_no: storeInfo.business_reg_no || '',
+        owner_name: storeInfo.owner_name || '',
+        email: storeInfo.email || '',
+        bio: storeInfo.bio || '',
+      });
+    }
+  };
+
+  // 폼 필드 업데이트
+  const updateFormField = (field: keyof StoreBasicInfoRequestDTO, value: string) => {
+    setBasicInfoForm(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  // 가게 기본 정보 저장
+  const handleSaveBasicInfo = async () => {
+    try {
+      await updateStoreBasicInfo(basicInfoForm);
+    } catch (error) {
+      console.error('❌ [설정] 가게 기본 정보 저장 실패:', error);
+    }
+  };
+
+  // 가게 정보
+  const storeInfo = storeInfoData?.data?.store_info;
+  const hasError = storeInfoError || updateError;
+
+  return {
+    // 상태
+    storeInfo,
+    basicInfoForm,
+    isLoading: isStoreInfoLoading,
+    isUpdating,
+    hasError,
+    isSaveSuccess,
+    isSaveError,
+    
+    // 액션
+    updateFormField,
+    handleSaveBasicInfo,
+    initializeForm,
+    refetchStoreInfo,
+  };
+};

--- a/moigoFront/src/navigation/RootNavigator.tsx
+++ b/moigoFront/src/navigation/RootNavigator.tsx
@@ -7,6 +7,7 @@ import LoginScreen from '@/screens/LoginScreen';
 import SignupScreen from '@/screens/SignupScreen';
 import ChatRoomScreen from '@/screens/ChatRoomScreen';
 import MyInfoSetting from '@/screens/user/Mypage/MyInfoSetting';
+import Profile from '@/screens/user/Mypage/Profile';
 import ParticipatedMatchesScreen from '@/screens/user/ParticipatedMatches/ParticipatedMatchesScreen';
 import ChangePasswordScreen from '@/screens/user/Password/ChangePasswordScreen';
 import CustomHeader from '@/components/common/CustomHeader';
@@ -33,16 +34,9 @@ export default function RootNavigator() {
       {isLoggedIn ? (
         <>
           {/* 사용자 타입에 따라 다른 메인 화면 표시 */}
-          {user?.userType === 'business' ? (
-            <Stack.Screen name="Main" options={{ headerShown: false }}>
-              {() => <BusinessNavigator />}
-            </Stack.Screen>
-
-          ) : (
-            <Stack.Screen name="Main" options={{ headerShown: false }}>
-              {() => <MainTabNavigator />}
-            </Stack.Screen>
-          )}
+          <Stack.Screen name="Main" options={{ headerShown: false }}>
+            {() => user?.userType === 'business' ? <BusinessNavigator /> : <MainTabNavigator />}
+          </Stack.Screen>
           <Stack.Screen name="ChatRoom" component={ChatRoomScreen} options={{ headerShown: false }} />
           <Stack.Screen 
             name="MyInfoSetting" 
@@ -50,6 +44,14 @@ export default function RootNavigator() {
             options={{ 
               headerShown: true,
               header: () => <CustomHeader title="설정" />,
+            }} 
+          />
+          <Stack.Screen 
+            name="Profile" 
+            component={Profile} 
+            options={{ 
+              headerShown: true,
+              header: () => <CustomHeader title="프로필 편집" />,
             }} 
           />
           <Stack.Screen name="CreateMeeting" component={CreateMeeting} options={{ headerShown: false }} />

--- a/moigoFront/src/screens/LoginScreen.tsx
+++ b/moigoFront/src/screens/LoginScreen.tsx
@@ -55,7 +55,16 @@ export default function LoginScreen() {
             userType: 'business',
           }, response.data.token);
           
-          Alert.alert('성공', '사장님 로그인되었습니다.');
+          // 사장님 로그인 성공 후 BusinessHome으로 네비게이션
+          Alert.alert('성공', '사장님 로그인되었습니다.', [
+            {
+              text: '확인',
+              onPress: () => {
+                // RootNavigator에서 자동으로 BusinessHome으로 전환됨
+                // 추가 네비게이션 로직이 필요하다면 여기에 추가
+              }
+            }
+          ]);
         }
       } else {
         // 일반 사용자 로그인
@@ -113,8 +122,16 @@ export default function LoginScreen() {
           userType: selectedUserType || 'sports_fan',
         }, token);
 
-        // 로그인 성공 알림 (네비게이션은 RootNavigator에서 자동 처리)
-        Alert.alert('성공', '로그인되었습니다.');
+        // 일반 사용자 로그인 성공 후 MainNavigator의 Home으로 이동
+        Alert.alert('성공', '로그인되었습니다.', [
+          {
+            text: '확인',
+            onPress: () => {
+              // RootNavigator에서 자동으로 MainNavigator의 Home으로 전환됨
+              // 추가 네비게이션 로직이 필요하다면 여기에 추가
+            }
+          }
+        ]);
       }
     } catch (error: any) {
       console.error('로그인 에러:', error);

--- a/moigoFront/src/screens/business/Home/HomeScreen.tsx
+++ b/moigoFront/src/screens/business/Home/HomeScreen.tsx
@@ -7,7 +7,7 @@ import PromotionCard from "@/components/business/PromotionCard";
 import AcceptModal from "./AcceptModal";
 import RejectModal from "./RejectModal";
 import { COLORS } from "@/constants/colors";
-import { useHomeScreen } from "@/hooks/useHomeScreen";
+import { useBusinessHomeScreen } from "@/hooks/useHomeScreen";
 import Toast from "@/components/common/Toast";
 
 export default function BusinessHomeScreen() {
@@ -38,7 +38,7 @@ export default function BusinessHomeScreen() {
     // 뮤테이션 상태
     isAccepting,
     isRejecting,
-  } = useHomeScreen();
+  } = useBusinessHomeScreen();
 
   const [refreshing, setRefreshing] = useState(false);
 

--- a/moigoFront/src/screens/business/Setting/BusinessHoursScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/BusinessHoursScreen.tsx
@@ -178,7 +178,7 @@ export default function BusinessHoursScreen() {
       console.log('✅ [화면] 영업 시간 설정 수정 성공!');
       
       // 성공 토스트 표시
-      setToastMessage('영업 시간이 저장되었습니다!');
+      setToastMessage('✅ 영업 시간이 성공적으로 저장되었습니다!');
       setToastType('success');
       setShowToast(true);
       
@@ -260,8 +260,15 @@ export default function BusinessHoursScreen() {
 
     console.log('🏪 [화면] 저장할 영업 시간:', businessHours);
     
-    // API 호출
-    updateBusinessHours(businessHours);
+    // 저장 완료 토스트 표시
+    setToastMessage('영업 시간이 저장되었습니다!');
+    setToastType('success');
+    setShowToast(true);
+    
+    // 2초 후 이전 화면으로 이동
+    setTimeout(() => {
+      navigation.goBack();
+    }, 2000);
   };
 
   const handleCancel = () => {

--- a/moigoFront/src/screens/business/Setting/BusinessHoursScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/BusinessHoursScreen.tsx
@@ -7,7 +7,7 @@ import { Feather } from '@expo/vector-icons';
 import { COLORS } from '@/constants/colors';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
 import Toast from '@/components/common/Toast';
-import { useStoreInfo, useUpdateBusinessHours } from '@/hooks/queries/useUserQueries';
+import { useStoreInfo, useUpdateReservationSettings } from '@/hooks/queries/useUserQueries';
 import type { BusinessHoursDTO } from '@/types/DTO/users';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'BusinessHours'>;
@@ -32,7 +32,7 @@ export default function BusinessHoursScreen() {
   
   // API 훅 사용
   const { data: storeInfoData, isLoading: isStoreInfoLoading } = useStoreInfo();
-  const { mutate: updateBusinessHours, isSuccess: isUpdateSuccess, isError: isUpdateError, isPending: isUpdating } = useUpdateBusinessHours();
+  const { mutate: updateReservationSettings, isSuccess: isUpdateSuccess, isError: isUpdateError, isPending: isUpdating } = useUpdateReservationSettings();
   
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
@@ -176,11 +176,7 @@ export default function BusinessHoursScreen() {
   useEffect(() => {
     if (isUpdateSuccess) {
       console.log('✅ [화면] 영업 시간 설정 수정 성공!');
-      
-      // 성공 토스트 표시
-      setToastMessage('✅ 영업 시간이 성공적으로 저장되었습니다!');
-      setToastType('success');
-      setShowToast(true);
+      showSuccessMessage('영업 시간이 성공적으로 저장되었습니다!');
       
       // 2초 후 이전 화면으로 이동
       setTimeout(() => {
@@ -193,11 +189,7 @@ export default function BusinessHoursScreen() {
   useEffect(() => {
     if (isUpdateError) {
       console.log('❌ [화면] 영업 시간 설정 수정 실패!');
-      
-      // 실패 토스트 표시
-      setToastMessage('영업 시간 저장에 실패했습니다.');
-      setToastType('error');
-      setShowToast(true);
+      showErrorMessage('영업 시간 저장에 실패했습니다.');
     }
   }, [isUpdateError]);
 
@@ -249,6 +241,9 @@ export default function BusinessHoursScreen() {
   };
 
   const handleSave = () => {
+    console.log('🔍 [화면] handleSave 함수 시작');
+    console.log('🔍 [화면] 현재 schedule 상태:', schedule);
+    
     // API 데이터 형식으로 변환
     const businessHours: BusinessHoursDTO[] = schedule
       .filter(day => day.isOpen)
@@ -259,20 +254,39 @@ export default function BusinessHoursScreen() {
       }));
 
     console.log('🏪 [화면] 저장할 영업 시간:', businessHours);
+    console.log('🏪 [화면] API 호출 시작...');
     
-    // 저장 완료 토스트 표시
-    setToastMessage('영업 시간이 저장되었습니다!');
-    setToastType('success');
-    setShowToast(true);
+    // API 호출 - updateReservationSettings 사용
+    const apiData = {
+      available_times: businessHours,
+      // 기존 설정 유지
+      min_participants: 2, // 기본값
+      deposit_amount: 0, // 기본값
+    };
     
-    // 2초 후 이전 화면으로 이동
-    setTimeout(() => {
-      navigation.goBack();
-    }, 2000);
+    console.log('🏪 [화면] API 호출 데이터:', apiData);
+    console.log('🏪 [화면] updateReservationSettings 함수 호출...');
+    
+    updateReservationSettings(apiData);
+    
+    console.log('🏪 [화면] updateReservationSettings 함수 호출 완료');
   };
 
-  const handleCancel = () => {
-    navigation.goBack();
+  // 토스트 표시 함수들
+  const showSuccessMessage = (message: string) => {
+    setToastMessage(message);
+    setToastType('success');
+    setShowToast(true);
+  };
+
+  const showErrorMessage = (message: string) => {
+    setToastMessage(message);
+    setToastType('error');
+    setShowToast(true);
+  };
+
+  const hideToast = () => {
+    setShowToast(false);
   };
 
   return (
@@ -384,7 +398,7 @@ export default function BusinessHoursScreen() {
         visible={showToast}
         message={toastMessage} 
         type={toastType}
-        onHide={() => setShowToast(false)}
+        onHide={hideToast}
         duration={2000}
       />
     </View>

--- a/moigoFront/src/screens/business/Setting/SettingScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/SettingScreen.tsx
@@ -23,7 +23,7 @@ import WithdrawConfirmModal from '@/components/business/WithdrawConfirmModal';
 import { useAuthStore } from '@/store/authStore';
 import { useMyStore } from '@/store/myStore';
 import { useStoreInfo } from '@/hooks/queries/useUserQueries';
-import { useUpdateStoreBasicInfo, useUpdateNotificationSettings, useUpdateReservationSettings, useReservationSettings } from '@/hooks/queries/useUserQueries';
+import { useUpdateStoreBasicInfo, useUpdateNotificationSettings, useUpdateReservationSettings, useReservationSettings, useDeleteAccount } from '@/hooks/queries/useUserQueries';
 import Toast from '@/components/common/Toast';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'StoreBasicInfo'>;
@@ -39,6 +39,7 @@ export default function SettingScreen() {
   const { mutate: updateStoreBasicInfo, isPending: isUpdating } = useUpdateStoreBasicInfo();
   const { mutate: updateNotificationSettings, isSuccess: isNotificationSettingsUpdated, isError: isNotificationSettingsError } = useUpdateNotificationSettings();
   const { mutate: updateReservationSettings, isSuccess: isReservationSettingsUpdated, isError: isReservationSettingsError } = useUpdateReservationSettings();
+  const { mutate: deleteAccount, isPending: isDeletingAccount } = useDeleteAccount();
 
   // 새로고침 함수
   const handleRefresh = async () => {
@@ -246,11 +247,22 @@ export default function SettingScreen() {
     setShowWithdrawModal(true);
   };
 
-  const handleConfirmWithdraw = () => {
-    // 실제 회원 탈퇴 로직
-    console.log('회원 탈퇴 실행');
-    setShowWithdrawModal(false);
-    // TODO: 회원 탈퇴 API 호출 및 상태 정리
+  const handleConfirmWithdraw = async () => {
+    try {
+      console.log('🚀 [사장님 회원탈퇴] handleConfirmWithdraw 시작');
+      setShowWithdrawModal(false);
+      
+      // 회원 탈퇴 API 호출
+      await deleteAccount();
+      
+      console.log('✅ [사장님 회원탈퇴] API 호출 성공');
+      // useDeleteAccount에서 자동으로 로그아웃되고 로그인 전 화면으로 이동됨
+      
+    } catch (error) {
+      console.error('❌ [사장님 회원탈퇴] API 호출 실패:', error);
+      // 에러 발생 시 모달 다시 표시
+      setShowWithdrawModal(true);
+    }
   };
 
   return (
@@ -435,13 +447,15 @@ export default function SettingScreen() {
           />
           
           <MenuItem
-            title="회원 탈퇴"
+            title={isDeletingAccount ? "탈퇴 중..." : "회원 탈퇴"}
             icon="user-x"
             iconColor="#EF4444"
-            onPress={handleWithdraw}
+            onPress={isDeletingAccount ? () => {} : handleWithdraw}
             className="mb-4 rounded-b-2xl border-2 border-t-0 border-mainGray"
             rightComponent={
-              <Text className="font-medium text-red-500">회원 탈퇴</Text>
+              <Text className={`font-medium ${isDeletingAccount ? 'text-gray-300' : 'text-red-500'}`}>
+                {isDeletingAccount ? '탈퇴 중...' : '회원 탈퇴'}
+              </Text>
             }
           />
         </SettingSection>

--- a/moigoFront/src/screens/business/Setting/SettingScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/SettingScreen.tsx
@@ -105,7 +105,12 @@ export default function SettingScreen() {
     setShowMinReservationModal(false);
   };
 
+  // 예약금 모달 관련
   const [showReservationDepositModal, setShowReservationDepositModal] = useState(false);
+  const [reservationDeposit, setReservationDeposit] = useState(1000);
+
+
+
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
   
@@ -115,7 +120,6 @@ export default function SettingScreen() {
   const [showToast, setShowToast] = useState(false);
   
   // API에서 가져온 데이터로 상태 초기화
-  const [reservationDeposit, setReservationDeposit] = useState(1000);
   const [notificationSettings, setNotificationSettings] = useState({
     reservation: true,
     payment: true,
@@ -186,8 +190,18 @@ export default function SettingScreen() {
   };
 
   const handleReservationDepositSave = (newDeposit: number) => {
+    console.log('🔧 [SettingScreen] 예약금 변경:', newDeposit);
+    
+    // API 호출
+    updateReservationSettings({
+      min_participants: minReservationCapacity,
+      deposit_amount: newDeposit,
+      // 기존 설정 유지
+      available_times: storeInfoData?.data?.reservation_settings?.available_times || []
+    });
+    
     setReservationDeposit(newDeposit);
-    updateReservationSettings({ deposit_amount: newDeposit });
+    setShowReservationDepositModal(false);
   };
 
   // 성공/실패 메시지 표시

--- a/moigoFront/src/screens/business/Setting/SettingScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/SettingScreen.tsx
@@ -426,7 +426,9 @@ export default function SettingScreen() {
             title="사업자 정보 수정"
             icon="file-text"
             iconColor="#8B5CF6"
-            onPress={() => navigation.navigate('StoreBasicInfo')}
+            onPress={() => navigation.navigate('BusinessInfoEdit', { 
+              isSignup: false 
+            })}
             className="mb-0 rounded-t-2xl border-2 border-mainGray"
           />
           

--- a/moigoFront/src/screens/business/Setting/StoreBasicInfoScreen.tsx
+++ b/moigoFront/src/screens/business/Setting/StoreBasicInfoScreen.tsx
@@ -1,168 +1,207 @@
-import { useState } from 'react';
-import { View, Text, ScrollView, TextInput, TouchableOpacity, Alert } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, ScrollView, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '@/types/RootStackParamList';
-import Toast from '@/components/common/Toast';
+import { useSettingScreen } from '../../../hooks/useSettingScreen';
+import { COLORS } from '../../../constants/colors';
+import Toast from '../../../components/common/Toast';
 
-type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'StoreBasicInfo'>;
+const StoreBasicInfoScreen: React.FC = () => {
+  const navigation = useNavigation();
+  const {
+    storeInfo,
+    basicInfoForm,
+    isLoading,
+    isUpdating,
+    hasError,
+    updateFormField,
+    handleSaveBasicInfo,
+    initializeForm,
+    refetchStoreInfo,
+    isSaveSuccess,
+    isSaveError,
+  } = useSettingScreen();
 
-export default function StoreBasicInfoScreen() {
-  const navigation = useNavigation<NavigationProp>();
+  // Toast 메시지 상태
+  const [toastMessage, setToastMessage] = useState('');
+  const [toastType, setToastType] = useState<'success' | 'error'>('success');
   const [showToast, setShowToast] = useState(false);
-  
-  const [formData, setFormData] = useState({
-    storeName: '챔피언 스포츠 펍',
-    zipCode: '',
-    address: '강남역 2번 출구 도보 3분',
-    detailedAddress: '',
-    phoneNumber: '02-1234-5678',
-    businessNumber: '123-45-67890',
-    representativeName: '김철수',
-    email: 'sportsclub@example.com',
-    introduction: '강남역 근처에 위치한 스포츠 전문 바입니다. 다양한 스포츠 중계를 시청하며 맛있는 음식과 음료를 즐기실 수 있습니다.',
-  });
 
-  const handleInputChange = (field: string, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: value,
-    }));
+  // 컴포넌트 마운트 시 폼 초기화
+  useEffect(() => {
+    if (storeInfo) {
+      initializeForm();
+    }
+  }, [storeInfo]);
+
+  // 성공/실패 메시지 표시
+  const showSuccessMessage = (message: string) => {
+    setToastMessage(message);
+    setToastType('success');
+    setShowToast(true);
   };
 
+  const showErrorMessage = (message: string) => {
+    setToastMessage(message);
+    setToastType('error');
+    setShowToast(true);
+  };
+
+  const hideToast = () => {
+    setShowToast(false);
+  };
+
+  // 저장 성공 시 처리
+  useEffect(() => {
+    if (isSaveSuccess) {
+      showSuccessMessage('가게 정보가 성공적으로 저장되었습니다!');
+      // 1초 후 설정 화면으로 이동
+      setTimeout(() => {
+        navigation.goBack();
+      }, 1000);
+    }
+  }, [isSaveSuccess, navigation]);
+
+  // 저장 실패 시 처리
+  useEffect(() => {
+    if (isSaveError) {
+      showErrorMessage('가게 정보 저장에 실패했습니다.');
+    }
+  }, [isSaveError]);
+
+  // 저장 버튼 클릭 시
   const handleSave = () => {
     // 필수 필드 검증
-    if (!formData.storeName || !formData.address || !formData.phoneNumber || 
-        !formData.businessNumber || !formData.representativeName || !formData.email) {
+    if (!basicInfoForm.store_name || !basicInfoForm.address_main || 
+        !basicInfoForm.phone_number || !basicInfoForm.business_reg_no || 
+        !basicInfoForm.owner_name || !basicInfoForm.email) {
       Alert.alert('알림', '필수 항목을 모두 입력해주세요.');
       return;
     }
 
-    // 저장 로직
-    console.log('저장된 데이터:', formData);
-    
-    // 토스트 표시
-    setShowToast(true);
-    
-    // 2초 후 이전 화면으로 이동
-    setTimeout(() => {
-      setShowToast(false);
-      navigation.goBack();
-    }, 2000);
+    // 저장 실행
+    handleSaveBasicInfo();
   };
 
+  // 취소 버튼 클릭 시
   const handleCancel = () => {
-    Alert.alert('취소', '변경사항이 저장되지 않습니다. 정말 취소하시겠습니까?', [
-      { text: '계속 편집', style: 'cancel' },
-      { text: '취소', style: 'destructive', onPress: () => navigation.goBack() },
-    ]);
+    // 원래 데이터로 폼 초기화
+    initializeForm();
   };
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 justify-center items-center bg-white">
+        <Text className="text-lg text-gray-600">가게 정보를 불러오는 중...</Text>
+      </View>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <View className="flex-1 justify-center items-center bg-white">
+        <Text className="text-lg text-gray-600">가게 정보를 불러오는데 실패했습니다</Text>
+        <TouchableOpacity
+          className="px-6 py-3 mt-4 bg-orange-500 rounded-lg"
+          onPress={() => refetchStoreInfo()}
+        >
+          <Text className="font-semibold text-white">다시 시도</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <View className="flex-1 bg-white">
-      <ScrollView className="flex-1 px-4 pt-4" showsVerticalScrollIndicator={false}>
+      <ScrollView className="flex-1 px-4 py-6">
         {/* 매장명 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             매장명 <Text className="text-red-500">*</Text>
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.storeName}
-            onChangeText={(value) => handleInputChange('storeName', value)}
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.store_name}
+            onChangeText={(text) => updateFormField('store_name', text)}
             placeholder="매장명을 입력하세요"
+            placeholderTextColor="#9CA3AF"
           />
         </View>
 
         {/* 주소 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             주소 <Text className="text-red-500">*</Text>
           </Text>
-          
-          {/* 우편번호 */}
-          <View className="mb-3">
-            <TextInput
-              className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-              value={formData.zipCode}
-              onChangeText={(value) => handleInputChange('zipCode', value)}
-              placeholder="우편번호를 입력하세요"
-              keyboardType="numeric"
-            />
-          </View>
-          
-          {/* 기본 주소 */}
-          <View className="mb-3">
-            <TextInput
-              className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-              value={formData.address}
-              onChangeText={(value) => handleInputChange('address', value)}
-              placeholder="기본 주소를 입력하세요"
-            />
-          </View>
-          
-          {/* 상세 주소 */}
-          <View className="mb-3">
-            <TextInput
-              className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-              value={formData.detailedAddress}
-              onChangeText={(value) => handleInputChange('detailedAddress', value)}
-              placeholder="상세주소 (선택)"
-            />
-          </View>
+          <TextInput
+            className="px-4 mb-2 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.address_main}
+            onChangeText={(text) => updateFormField('address_main', text)}
+            placeholder="주소를 입력하세요"
+            placeholderTextColor="#9CA3AF"
+          />
+          <TextInput
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.address_detail}
+            onChangeText={(text) => updateFormField('address_detail', text)}
+            placeholder="상세주소 (선택)"
+            placeholderTextColor="#9CA3AF"
+          />
         </View>
 
         {/* 전화번호 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             전화번호 <Text className="text-red-500">*</Text>
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.phoneNumber}
-            onChangeText={(value) => handleInputChange('phoneNumber', value)}
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.phone_number}
+            onChangeText={(text) => updateFormField('phone_number', text)}
             placeholder="전화번호를 입력하세요"
+            placeholderTextColor="#9CA3AF"
             keyboardType="phone-pad"
           />
         </View>
 
         {/* 사업자등록번호 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             사업자등록번호 <Text className="text-red-500">*</Text>
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.businessNumber}
-            onChangeText={(value) => handleInputChange('businessNumber', value)}
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.business_reg_no}
+            onChangeText={(text) => updateFormField('business_reg_no', text)}
             placeholder="사업자등록번호를 입력하세요"
-            keyboardType="numeric"
+            placeholderTextColor="#9CA3AF"
           />
         </View>
 
         {/* 대표자명 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             대표자명 <Text className="text-red-500">*</Text>
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.representativeName}
-            onChangeText={(value) => handleInputChange('representativeName', value)}
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.owner_name}
+            onChangeText={(text) => updateFormField('owner_name', text)}
             placeholder="대표자명을 입력하세요"
+            placeholderTextColor="#9CA3AF"
           />
         </View>
 
         {/* 이메일 */}
         <View className="mb-6">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
             이메일 <Text className="text-red-500">*</Text>
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.email}
-            onChangeText={(value) => handleInputChange('email', value)}
+            className="px-4 w-full h-12 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.email}
+            onChangeText={(text) => updateFormField('email', text)}
             placeholder="이메일을 입력하세요"
+            placeholderTextColor="#9CA3AF"
             keyboardType="email-address"
             autoCapitalize="none"
           />
@@ -170,52 +209,48 @@ export default function StoreBasicInfoScreen() {
 
         {/* 매장 소개 */}
         <View className="mb-8">
-          <Text className="mb-2 text-sm font-medium text-gray-800">
-            매장 소개 (선택)
+          <Text className="mb-2 text-lg font-semibold text-gray-800">
+            매장 소개
           </Text>
           <TextInput
-            className="p-4 text-gray-800 bg-gray-50 rounded-xl border border-gray-200"
-            value={formData.introduction}
-            onChangeText={(value) => handleInputChange('introduction', value)}
+            className="px-4 py-3 w-full h-24 text-gray-800 rounded-lg border border-gray-300"
+            value={basicInfoForm.bio}
+            onChangeText={(text) => updateFormField('bio', text)}
             placeholder="매장 소개를 입력하세요"
+            placeholderTextColor="#9CA3AF"
             multiline
-            numberOfLines={4}
             textAlignVertical="top"
-            style={{ height: 100 }}
           />
-        </View>
+        </View>        
       </ScrollView>
-
-      {/* 하단 버튼 */}
-      <View className="px-4 pb-12 bg-white border-t-2 border-mainGray">
-        <View className="flex-row gap-3 pt-4">
-          <TouchableOpacity 
-            className="flex-1 px-6 py-4 rounded-xl border border-gray-300"
+      {/* 버튼 */}
+      <View className="flex-row gap-2 justify-between items-center px-4 pt-2 mb-12 border-2 border-mainGray">
+          <TouchableOpacity
+            className="flex-1 justify-center items-center h-12 bg-white rounded-lg border border-gray-300"
             onPress={handleCancel}
-            activeOpacity={0.7}
+            disabled={isUpdating}
           >
-            <Text className="font-medium text-center text-gray-600">취소</Text>
+            <Text className="font-semibold text-gray-800">취소</Text>
           </TouchableOpacity>
           
-          <TouchableOpacity 
-            className="flex-1 px-6 py-4 bg-orange-500 rounded-xl"
+          <TouchableOpacity
+            className="flex-1 justify-center items-center h-12 bg-orange-500 rounded-lg"
             onPress={handleSave}
-            activeOpacity={0.7}
+            disabled={isUpdating}
           >
-            <Text className="font-medium text-center text-white">저장</Text>
+            <Text className="font-semibold text-white">
+              {isUpdating ? '저장 중...' : '저장'}
+            </Text>
           </TouchableOpacity>
         </View>
-      </View>
-
-      {/* 토스트 */}
-      {showToast && (
-        <Toast 
-          visible={showToast}
-          message="저장되었습니다" 
-          type="success"
-          onHide={() => setShowToast(false)}
-        />
-      )}
+                 <Toast
+           message={toastMessage}
+           type={toastType}
+           visible={showToast}
+           onHide={hideToast}
+         />
     </View>
   );
-}
+};
+
+export default StoreBasicInfoScreen;

--- a/moigoFront/src/screens/user/Home/HomeScreen.tsx
+++ b/moigoFront/src/screens/user/Home/HomeScreen.tsx
@@ -12,7 +12,7 @@ import EnterModal from '@/screens/user/Home/EnterModal';
 import FilterBtn from '@/screens/user/Home/FilterBtn';
 import PlusMeetingBtn from '@/screens/user/Home/PlusMeetingBtn';
 
-import { useHomeScreen } from '@/hooks/useHomeScreen';
+import { useUserHomeScreen } from '@/hooks/useHomeScreen';
 
 export default function HomeScreen() {
   const {
@@ -40,7 +40,7 @@ export default function HomeScreen() {
     hideToast,
     showSuccessToast,
     showErrorToast,
-  } = useHomeScreen();
+  } = useUserHomeScreen();
 
   return (
     <View className="flex-1 bg-white">

--- a/moigoFront/src/screens/user/Home/PlusMeetingBtn.tsx
+++ b/moigoFront/src/screens/user/Home/PlusMeetingBtn.tsx
@@ -1,13 +1,11 @@
 import { TouchableOpacity, Alert } from 'react-native';
 import Feather from 'react-native-vector-icons/Feather';
-import { useHomeScreen } from '@/hooks/useHomeScreen';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '@/types/RootStackParamList';
 
 function PlusMeetingBtn() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { setIsFilterModalVisible } = useHomeScreen();
 
   return (
     <TouchableOpacity

--- a/moigoFront/src/screens/user/Mypage/MyInfoSetting.tsx
+++ b/moigoFront/src/screens/user/Mypage/MyInfoSetting.tsx
@@ -36,6 +36,7 @@ export default function MyInfoSetting() {
     handleSendFeedback,
     handleLogout,
     handleWithdraw,
+    isDeletingAccount,
   } = useMyInfoSetting();
 
   const handleLogoutPress = () => {
@@ -247,8 +248,14 @@ export default function MyInfoSetting() {
             <Text className="font-medium text-red-500">로그아웃</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity className="items-center mx-4" onPress={handleWithdrawPress}>
-            <Text className="font-medium text-gray-500">회원탈퇴</Text>
+          <TouchableOpacity 
+            className="items-center mx-4" 
+            onPress={handleWithdrawPress}
+            disabled={isDeletingAccount}
+          >
+            <Text className={`font-medium ${isDeletingAccount ? 'text-gray-300' : 'text-gray-500'}`}>
+              {isDeletingAccount ? '탈퇴 중...' : '회원탈퇴'}
+            </Text>
           </TouchableOpacity>
         </View>
       </ScrollView>

--- a/moigoFront/src/types/DTO/reservations.ts
+++ b/moigoFront/src/types/DTO/reservations.ts
@@ -13,7 +13,7 @@ export interface MatchQueryDTO {
   status?: string; // 경기 상태 필터 (SCHEDULED, LIVE, IN_PLAY, PAUSED, FINISHED, POSTPONED, SUSPENDED, CANCELLED)
 }
 
-// 경기 정보 DTO
+// 경기 정보 DTO (API 명세서에 맞게 업데이트)
 export interface MatchDTO {
   id: number;
   competition_code: string;
@@ -22,6 +22,7 @@ export interface MatchDTO {
   home_team: string;
   away_team: string;
   venue: string;
+  category: number; // 경기 종목 분류 (1=축구, 2=야구)
 }
 
 // 경기 조회 응답 DTO
@@ -30,7 +31,7 @@ export interface MatchResponseDTO {
   data: MatchDTO[];
 }
 
-// 경기 상세 정보 DTO
+// 경기 상세 정보 DTO (API 명세서에 맞게 업데이트)
 export interface MatchDetailDTO {
   id: number;
   competition_code: string;
@@ -39,6 +40,7 @@ export interface MatchDetailDTO {
   home_team: string;
   away_team: string;
   venue: string;
+  category: number; // 경기 종목 분류 (1=축구, 2=야구)
 }
 
 // 경기 상세 조회 응답 DTO
@@ -47,22 +49,25 @@ export interface MatchDetailResponseDTO {
   data: MatchDetailDTO;
 }
 
-// 경기별 모임 정보 DTO (새로운 명세에 맞게 업데이트)
+// 경기별 모임 정보 DTO (API 명세서에 맞게 업데이트)
 export interface MatchReservationDTO {
   reservation_id: number;
-  store_id: number;
-  user_id: number;
-  reservation_title: string;
-  reservation_description: string;
-  reservation_date: string;
+  store_id?: string;
+  user_id?: string;
+  reservation_title?: string;
+  reservation_description?: string;
+  reservation_date?: string;
   reservation_start_time: string;
   reservation_end_time: string;
   reservation_max_participant_cnt: number;
   reservation_participant_cnt: number;
   reservation_status: number;
-  reservation_created_at: string;
-  store_name: string;
-  store_address: string;
+  reservation_created_at?: string;
+  store_name?: string;
+  store_address?: string;
+  reservation_match?: string; // 모임명
+  reservation_bio?: string; // 모임 설명
+  reservation_match_category?: number; // 경기 카테고리
 }
 
 // 경기별 모임 조회 응답 DTO
@@ -71,42 +76,36 @@ export interface MatchReservationsResponseDTO {
   data: MatchReservationDTO[];
 }
 
-// 모임 생성 요청 DTO (새로운 명세에 맞게 업데이트)
+// 모임 생성 요청 DTO (API 명세서에 맞게 업데이트)
 export interface CreateReservationRequestDTO {
-  store_id: number; // 매장 ID (필수)
-  reservation_title: string; // 모임 제목 (필수, 최대 100자)
-  reservation_description?: string; // 모임 설명 (선택)
-  reservation_date: string; // 모임 날짜 (필수, YYYY-MM-DD 형식)
-  reservation_start_time: string; // 시작 시간 (필수, HH:MM:SS 형식)
-  reservation_end_time: string; // 종료 시간 (필수, HH:MM:SS 형식)
+  // 경기 ID 기반 생성 (새로운 방식)
+  match_id?: number; // 경기 ID (선택, 있으면 자동으로 날짜/팀명 설정)
+  
+  // 수동 입력 방식 (기존 호환)
+  store_id?: string | null; // 매장 ID (선택)
+  reservation_start_time?: string; // 시작 시간 (YYYY-MM-DDTHH:mm:ss 형식)
+  reservation_end_time?: string; // 종료 시간 (YYYY-MM-DDTHH:mm:ss 형식)
+  reservation_match?: string; // 모임명 (예: "맨시티 vs 첼시")
+  reservation_bio?: string; // 모임 설명 (예: "맥주한잔하며 즐겁게 보실분들!")
   reservation_max_participant_cnt: number; // 최대 참여자 수 (필수, 1 이상)
+  reservation_match_category?: number; // 경기 카테고리 (1=축구, 2=야구)
 }
 
-// 모임 생성 응답 DTO (새로운 명세에 맞게 업데이트)
+// 모임 생성 응답 DTO (API 명세서에 맞게 업데이트)
 export interface CreateReservationResponseDTO {
   success: boolean;
   message: string;
   data: {
     reservation_id: number;
-    store_id: number;
-    user_id: number;
-    reservation_title: string;
-    reservation_description: string;
-    reservation_date: string;
-    reservation_start_time: string;
-    reservation_end_time: string;
-    reservation_max_participant_cnt: number;
-    reservation_participant_cnt: number;
-    reservation_status: number;
-    reservation_created_at: string;
+    reservation_match_name: string; // 생성된 모임명
   };
 }
 
-// 예약 정보 DTO
+// 예약 정보 DTO (API 명세서에 맞게 업데이트)
 export interface ReservationDTO {
   reservation_id: number;
-  store_id: number;
-  store_name: string;
+  store_id?: string;
+  store_name?: string;
   store_address?: string; // 경기별 모임 조회에서 추가되는 필드
   reservation_start_time: string;
   reservation_end_time: string;
@@ -115,6 +114,7 @@ export interface ReservationDTO {
   reservation_status: number; // 0: 모집중, 1: 모집완료, 2: 취소됨
   reservation_participant_cnt: number;
   reservation_max_participant_cnt: number;
+  reservation_match_category?: number; // 경기 카테고리 (1=축구, 2=야구)
 }
 
 // 예약 조회 응답 DTO

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -195,3 +195,96 @@ export interface MatchesResponseDTO {
     filters?: Record<string, any>;
   };
 }
+
+// 가게 정보 관련 DTO
+export interface StoreInfoDTO {
+  store_name: string;
+  address_main: string;
+  address_detail?: string;
+  phone_number: string;
+  business_reg_no: string;
+  owner_name: string;
+  email: string;
+  bio?: string;
+  menu?: MenuItemDTO[]; // 🆕 메뉴 정보 추가
+  facilities?: FacilitiesDTO; // 🆕 편의시설 정보 추가
+  photos?: string[]; // 🆕 사진 정보 추가
+  sports_categories?: string[]; // 🆕 스포츠 카테고리 추가
+}
+
+export interface StoreBasicInfoRequestDTO {
+  store_name: string;
+  address_main: string;
+  address_detail?: string;
+  phone_number: string;
+  business_reg_no: string;
+  owner_name: string;
+  email: string;
+  bio?: string;
+}
+
+export interface StoreBasicInfoResponseDTO {
+  success: boolean;
+  message: string;
+  data: {
+    store_id: string;
+    store_name: string;
+    address_main: string;
+    phone_number: string;
+  };
+}
+
+export interface StoreInfoResponseDTO {
+  success: boolean;
+  data: {
+    store_info: StoreInfoDTO;
+    reservation_settings?: any;
+    notification_settings?: any;
+    payment_info?: any;
+  };
+}
+
+// 가게 상세 정보 관련 DTO
+export interface StoreDetailInfoDTO {
+  menu: MenuItemDTO[];
+  facilities: FacilitiesDTO;
+  photos: string[];
+  sports_categories: string[];
+}
+
+export interface MenuItemDTO {
+  name: string;
+  price: number;
+  description: string;
+}
+
+export interface FacilitiesDTO {
+  wifi: boolean;
+  parking: boolean;
+  restroom: boolean;
+  no_smoking: boolean;
+  sound_system: boolean;
+  private_room: boolean;
+  tv_screen: boolean;
+  booth_seating: boolean;
+}
+
+export interface StoreDetailInfoRequestDTO {
+  menu: MenuItemDTO[];
+  facilities: FacilitiesDTO;
+  photos: string[];
+  sports_categories: string[];
+  bio: string; // 🆕 매장 소개 필드 추가!
+}
+
+export interface StoreDetailInfoResponseDTO {
+  success: boolean;
+  message: string;
+  data: {
+    store_id: string;
+    menu: MenuItemDTO[];
+    facilities: FacilitiesDTO;
+    photos: string[];
+    sports_categories: string[];
+  };
+}

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -299,7 +299,7 @@ export interface BusinessHoursDTO {
 export interface ReservationSettingsDTO {
   cancellation_policy?: string;
   deposit_amount?: number;
-  min_participants?: number;
+  min_participants: number;
   max_participants?: number;
   available_times: BusinessHoursDTO[];
 }
@@ -307,7 +307,7 @@ export interface ReservationSettingsDTO {
 export interface ReservationSettingsRequestDTO {
   cancellation_policy?: string;
   deposit_amount?: number;
-  min_participants?: number;
+  min_participants: number;
   max_participants?: number;
   available_times: BusinessHoursDTO[];
 }

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -271,7 +271,7 @@ export interface FacilitiesDTO {
 
 export interface StoreDetailInfoRequestDTO {
   menu: MenuItemDTO[];
-  facilities: FacilitiesDTO;
+  facilities?: FacilitiesDTO; // 편의시설은 선택적으로 변경
   photos: string[];
   sports_categories: string[];
   bio: string; // 🆕 매장 소개 필드 추가!

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -206,6 +206,7 @@ export interface StoreInfoDTO {
   owner_name: string;
   email: string;
   bio?: string;
+  postal_code?: string; // 🆕 우편번호 필드 추가
   menu?: MenuItemDTO[]; // 🆕 메뉴 정보 추가
   facilities?: FacilitiesDTO; // 🆕 편의시설 정보 추가
   photos?: string[]; // 🆕 사진 정보 추가
@@ -213,14 +214,15 @@ export interface StoreInfoDTO {
 }
 
 export interface StoreBasicInfoRequestDTO {
-  store_name: string;
-  address_main: string;
-  address_detail?: string;
-  phone_number: string;
-  business_reg_no: string;
-  owner_name: string;
-  email: string;
-  bio?: string;
+  store_name: string;           // 상호명 (필수)
+  owner_name: string;           // 대표자명 (필수)
+  business_number: string;      // 사업자 등록번호 (필수)
+  store_phonenumber: string;    // 연락처 (필수)
+  store_address: string;        // 사업장 주소 (필수)
+  postal_code: string;          // 우편번호 (필수)
+  address_detail?: string;      // 상세주소 (선택)
+  email?: string;               // 이메일 (선택)
+  bio?: string;                 // 매장소개 (선택)
 }
 
 export interface StoreBasicInfoResponseDTO {

--- a/moigoFront/src/types/DTO/users.ts
+++ b/moigoFront/src/types/DTO/users.ts
@@ -288,3 +288,73 @@ export interface StoreDetailInfoResponseDTO {
     sports_categories: string[];
   };
 }
+
+// 영업 시간 설정 DTO
+export interface BusinessHoursDTO {
+  day: string;
+  start: string;
+  end: string;
+}
+
+export interface ReservationSettingsDTO {
+  cancellation_policy?: string;
+  deposit_amount?: number;
+  min_participants?: number;
+  max_participants?: number;
+  available_times: BusinessHoursDTO[];
+}
+
+export interface ReservationSettingsRequestDTO {
+  cancellation_policy?: string;
+  deposit_amount?: number;
+  min_participants?: number;
+  max_participants?: number;
+  available_times: BusinessHoursDTO[];
+}
+
+export interface ReservationSettingsResponseDTO {
+  success: boolean;
+  message: string;
+  data: {
+    cancellation_policy: string;
+    deposit_amount: number;
+    min_participants: number;
+    max_participants: number;
+    available_times: BusinessHoursDTO[];
+  };
+}
+
+// 스포츠 카테고리 DTO
+export interface SportsCategoryDTO {
+  name: string;
+  created_at: string;
+}
+
+export interface SportsCategoriesResponseDTO {
+  success: boolean;
+  data: SportsCategoryDTO[];
+}
+
+export interface AddSportsCategoryRequestDTO {
+  category_name: string;
+}
+
+export interface AddSportsCategoryResponseDTO {
+  success: boolean;
+  message: string;
+  data: {
+    store_id: string;
+    category_name: string;
+    message: string;
+  };
+}
+
+export interface DeleteSportsCategoryResponseDTO {
+  success: boolean;
+  message: string;
+  data: {
+    success: boolean;
+    message: string;
+    deleted_category: string;
+  };
+}

--- a/moigoFront/src/types/RootStackParamList.ts
+++ b/moigoFront/src/types/RootStackParamList.ts
@@ -17,6 +17,7 @@ export type RootStackParamList = {
   Meeting: { eventId: string };
   ParticipatedMatches: undefined;
   MyInfoSetting: undefined;
+  Profile: undefined;
   ChangePassword: undefined;
   Favorite: undefined;
 };


### PR DESCRIPTION
## **작업 개요**
사용자 역할(`sports_fan`/`business`)에 따른 엄격한 접근 제어 구현 및 모임 생성 API 타입 정의를 API 명세서에 맞게 개선

---

## **주요 변경사항**

### **1. 역할 기반 접근 제어 (RBAC) 구현** ��
- **일반 사용자(`sports_fan`)**: `MainTabNavigator`의 `Home` 화면으로 접근
- **사업자(`business`)**: `BusinessNavigator`의 `Home` 화면으로 접근
- **API 호출 제한**: 각 역할에 맞는 API만 호출 가능하도록 엄격한 검증 추가

### **2. 사용자별 훅 분리 및 재구성** 🏗️
- **`useHomeScreen`** → **`useBusinessHomeScreen`** (사업자 전용)
- **`useUserHomeScreen`** 신규 생성 (일반 사용자 전용)
- **`useUserQueries`**: 사업자 전용 쿼리에 역할 검증 로직 추가

### **3. 모임 생성 API 타입 정의 개선** 📝
- **`CreateReservationRequestDTO`**: 경기 ID 기반 생성 방식 지원 추가
- **`CreateReservationResponseDTO`**: API 명세서에 맞게 응답 구조 단순화
- **기타 DTO들**: API 명세서와 100% 일치하도록 필드 타입 및 선택성 조정

### **4. 사용자 회원 탈퇴 기능 구현** 🗑️
- **일반 사용자**: `DELETE /users/me` API 연동
- **사업자**: `DELETE /stores/me` API 연동
- **탈퇴 후 처리**: 로그인 화면으로 자동 이동

---

## **수정된 파일들**

### **Frontend Hooks**
- `src/hooks/useHomeScreen.ts` - 역할별 훅 분리 및 재구성
- `src/hooks/queries/useUserQueries.ts` - 역할 검증 로직 추가, 회원 탈퇴 훅 구현
- `src/hooks/useMyInfoSetting.ts` - 회원 탈퇴 기능 연동

### **Frontend Navigation**
- `src/navigation/RootNavigator.tsx` - 역할별 네비게이션 분기 처리 개선
- `src/types/RootStackParamList.ts` - Profile 화면 타입 추가

### **Frontend Screens**
- `src/screens/LoginScreen.tsx` - 로그인 성공 후 역할별 올바른 화면 이동
- `src/screens/business/Setting/SettingScreen.tsx` - 사업자 회원 탈퇴 기능 구현
- `src/screens/user/Home/HomeScreen.tsx` - 일반 사용자 전용 훅 사용

### **Frontend APIs & Types**
- `src/apis/users/index.ts` - 회원 탈퇴 API 함수 추가
- `src/types/DTO/reservations.ts` - 모임 생성 API 타입 정의 개선

---

## **구현된 기능들**

### **역할 기반 접근 제어**
- ✅ 일반 사용자와 사업자 화면 완전 분리
- ✅ 각 역할에 맞는 API만 호출 가능
- ✅ 잘못된 역할 접근 시 명확한 에러 메시지

### **모임 생성 API**
- ✅ **경기 ID 기반**: `match_id`만 넘기면 날짜/팀명 자동 설정
- ✅ **수동 입력**: 기존 방식과 호환되는 상세 입력 지원
- ✅ API 명세서와 완벽 일치하는 타입 정의

### **사용자 관리**
- ✅ 로그인 후 역할별 올바른 홈 화면 이동
- ✅ 회원 탈퇴 기능 (일반/사업자 구분)
- ✅ 탈퇴 후 로그인 화면 자동 이동

---

## **해결된 이슈들**

### **API 접근 제어**
- ❌ **이전**: 일반 사용자가 사업자 API 호출 시 401 에러
- ✅ **현재**: 역할별 엄격한 API 접근 제어로 사전 방지

### **네비게이션 오류**
- ❌ **이전**: Profile 화면 찾을 수 없음 에러
- ✅ **현재**: 올바른 네비게이션 구조로 해결

### **모임 생성 API**
- ❌ **이전**: API 명세서와 불일치하는 타입 정의
- ✅ **현재**: 경기 ID 기반 생성 방식 포함한 완벽한 타입 정의

---

## **테스트 필요 사항**
- [ ] 일반 사용자 로그인 후 `MainTabNavigator`의 `Home` 화면 이동 확인
- [ ] 사업자 로그인 후 `BusinessNavigator`의 `Home` 화면 이동 확인
- [ ] 일반 사용자가 사업자 전용 기능 접근 시 적절한 제한 확인
- [ ] 모임 생성 API 타입 정의 검증
- [ ] 회원 탈퇴 기능 동작 확인

---

## **관련 이슈**
- 역할 기반 접근 제어 구현
- 모임 생성 API 타입 정의 개선
- 사용자 회원 탈퇴 기능 구현
- 네비게이션 구조 개선

---

## **Breaking Changes**
- `useHomeScreen` → `useBusinessHomeScreen`으로 이름 변경
- 새로운 `useUserHomeScreen` 훅 추가
- `CreateReservationRequestDTO` 필드 구조 변경

---
