### PR TITLE
feat: 푸시 딥링크

### DIFF
--- a/moigoFront/App.tsx
+++ b/moigoFront/App.tsx
@@ -3,7 +3,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LogBox, Platform } from 'react-native';
 import Constants from 'expo-constants';
-import RootNavigator from '@/navigation/RootNavigator';
+import RootNavigator, { linking } from '@/navigation/RootNavigator';
 import { healthCheck } from '@/apis/apiClient';
 import './global.css';
 
@@ -64,7 +64,7 @@ export default function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <NavigationContainer ref={navigationRef}>
+      <NavigationContainer ref={navigationRef} linking={linking}>
         <RootNavigator />
       </NavigationContainer>
     </QueryClientProvider>

--- a/moigoFront/App.tsx
+++ b/moigoFront/App.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LogBox, Platform } from 'react-native';
+import { LogBox, Platform, View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import Constants from 'expo-constants';
 import RootNavigator, { linking } from '@/navigation/RootNavigator';
 import { healthCheck } from '@/apis/apiClient';
 import './global.css';
 
 import { usePushNotifications } from '@/hooks/usePushNotifications';
+import PushNotificationBanner from '@/components/common/PushNotificationBanner';
+import { useAuthStore } from '@/store/authStore';
+import { useNotificationStore } from '@/store/notificationStore';
 
 // 환경변수 로깅
 const { API_URL, WS_URL } = (Constants.expoConfig?.extra ?? {}) as any;
@@ -46,27 +50,92 @@ const queryClient = new QueryClient({
 });
 
 export default function App() {
-  const { registerForPushNotificationsAsync } = usePushNotifications();
   const navigationRef = React.useRef<any>(null);
+  const { user } = useAuthStore();
+  const { addNotification } = useNotificationStore();
+  
+  // 푸시 알림 배너 상태
+  const [bannerVisible, setBannerVisible] = React.useState(false);
+  const [bannerData, setBannerData] = React.useState({
+    title: '',
+    body: '',
+    onPress: () => {},
+  });
 
-  // 앱 시작 시 푸시 알림 설정
-  React.useEffect(() => {
-    // 푸시 알림 등록
-    registerForPushNotificationsAsync().then(token => {
-      if (token) {
-        console.log('Push notification token:', token);
-        // 토큰은 로그인 시 서버로 전송됩니다
+  // 푸시 알림 핸들러
+  const { registerForPushNotificationsAsync } = usePushNotifications({
+    onNavigate: (screen: string, params?: any) => {
+      console.log('푸시 알림 네비게이션:', { screen, params });
+      if (navigationRef.current) {
+        navigationRef.current.navigate(screen, params);
       }
-    }).catch(error => {
-      console.error('Push notification registration failed:', error);
-    });
+    },
+    onShowBanner: (title: string, body: string, onPress: () => void) => {
+      console.log('푸시 알림 배너 표시:', { title, body });
+      setBannerData({ title, body, onPress });
+      setBannerVisible(true);
+    },
+    onSaveNotification: (notification) => {
+      console.log('알림 저장:', notification);
+      addNotification({
+        type: notification.type as any,
+        title: notification.title,
+        body: notification.body,
+        data: notification.data,
+      });
+    },
+    currentUserType: user?.userType,
+  });
+
+  // 앱 시작 시 자동 로그인 체크 및 푸시 알림 설정
+  React.useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        // 1. 자동 로그인 체크
+        console.log('자동 로그인 체크 시작...');
+        const isAutoLoginSuccess = await user ? true : false; // Zustand persist가 자동으로 복원
+        
+        if (isAutoLoginSuccess) {
+          console.log('자동 로그인 성공');
+        } else {
+          console.log('자동 로그인 없음 또는 실패');
+        }
+
+        // 2. 푸시 알림 등록
+        const token = await registerForPushNotificationsAsync();
+        if (token) {
+          console.log('Push notification token:', token);
+          // 토큰은 로그인 시 서버로 전송됩니다
+        }
+      } catch (error) {
+        console.error('앱 초기화 중 오류:', error);
+      }
+    };
+
+    initializeApp();
   }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <NavigationContainer ref={navigationRef} linking={linking}>
-        <RootNavigator />
-      </NavigationContainer>
-    </QueryClientProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <QueryClientProvider client={queryClient}>
+        <View style={{ flex: 1 }}>
+          <NavigationContainer ref={navigationRef} linking={linking}>
+            <RootNavigator />
+          </NavigationContainer>
+          
+          {/* 푸시 알림 배너 */}
+          <PushNotificationBanner
+            visible={bannerVisible}
+            title={bannerData.title}
+            body={bannerData.body}
+            onPress={() => {
+              setBannerVisible(false);
+              bannerData.onPress();
+            }}
+            onDismiss={() => setBannerVisible(false)}
+          />
+        </View>
+      </QueryClientProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/moigoFront/app.json
+++ b/moigoFront/app.json
@@ -7,6 +7,7 @@
     "icon": "./assets/spotple-icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
+    "scheme": "moigo",
     "splash": {
       "image": "./assets/spotple-icon.png",
       "resizeMode": "contain",
@@ -16,6 +17,7 @@
       "icon": "./assets/spotple-icon.png",
       "supportsTablet": true,
       "bundleIdentifier": "com.sehankim.spotple",
+      "associatedDomains": ["applinks:moigo.com"],
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
@@ -26,7 +28,20 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-        "package": "com.sehankim.moigoFront"
+      "package": "com.sehankim.moigoFront",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "moigo",
+              "host": "*"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "bundler": "metro",

--- a/moigoFront/package-lock.json
+++ b/moigoFront/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/ngrok": "^4.1.3",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.2",
         "@react-navigation/native": "^7.1.14",
         "@react-navigation/native-stack": "^7.3.21",
@@ -30,6 +31,7 @@
         "react": "19.0.0",
         "react-hook-form": "^7.61.1",
         "react-native": "0.79.5",
+        "react-native-gesture-handler": "^2.28.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.12.0",
@@ -1549,6 +1551,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3154,6 +3168,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-19.1.0.tgz",
@@ -4336,6 +4362,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -8459,6 +8491,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -9018,6 +9065,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -10253,6 +10309,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -12246,6 +12314,21 @@
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
       "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/moigoFront/package.json
+++ b/moigoFront/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@expo/ngrok": "^4.1.3",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.2",
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.21",
@@ -20,14 +21,18 @@
     "babel-preset-expo": "~13.0.0",
     "date-fns": "^4.1.0",
     "expo": "~53.0.17",
+    "expo-constants": "~17.1.7",
     "expo-dev-client": "~5.2.4",
+    "expo-device": "~7.1.4",
     "expo-linear-gradient": "^14.1.5",
+    "expo-notifications": "~0.31.4",
     "expo-status-bar": "~2.2.3",
     "nativewind": "^4.1.23",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "react": "19.0.0",
     "react-hook-form": "^7.61.1",
     "react-native": "0.79.5",
+    "react-native-gesture-handler": "^2.28.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.12.0",
@@ -35,10 +40,7 @@
     "socket.io-client": "^4.7.4",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.17",
-    "zustand": "^5.0.6",
-    "expo-notifications": "~0.31.4",
-    "expo-device": "~7.1.4",
-    "expo-constants": "~17.1.7"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/moigoFront/src/components/common/PushNotificationBanner.tsx
+++ b/moigoFront/src/components/common/PushNotificationBanner.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, TouchableOpacity, Animated, Platform, StatusBar } from 'react-native';
+import { PanGestureHandler, State } from 'react-native-gesture-handler';
+import { Feather } from '@expo/vector-icons';
+
+interface PushNotificationBannerProps {
+  visible: boolean;
+  title: string;
+  body: string;
+  onPress: () => void;
+  onDismiss: () => void;
+  duration?: number;
+  icon?: keyof typeof Feather.glyphMap;
+}
+
+export default function PushNotificationBanner({
+  visible,
+  title,
+  body,
+  onPress,
+  onDismiss,
+  duration = 4000,
+  icon = 'bell'
+}: PushNotificationBannerProps) {
+  // StatusBar 높이 + 여백 계산
+  const statusBarHeight = Platform.OS === 'ios' ? 44 : StatusBar.currentHeight || 24;
+  const slideAnim = new Animated.Value(-100);
+  const fadeAnim = new Animated.Value(0);
+  const panY = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      // 배너 나타나기
+      Animated.parallel([
+        Animated.timing(slideAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      // 자동으로 사라지기
+      const timer = setTimeout(() => {
+        hideBanner();
+      }, duration);
+
+      return () => clearTimeout(timer);
+    }
+  }, [visible]);
+
+  const hideBanner = () => {
+    Animated.parallel([
+      Animated.timing(slideAnim, {
+        toValue: -100,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.timing(panY, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+    ]).start(() => {
+      onDismiss();
+    });
+  };
+
+  // 팬 제스처 핸들러
+  const onGestureEvent = Animated.event(
+    [{ nativeEvent: { translationY: panY } }],
+    { useNativeDriver: true }
+  );
+
+  const onHandlerStateChange = ({ nativeEvent }: any) => {
+    if (nativeEvent.state === State.END) {
+      const { translationY, velocityY } = nativeEvent;
+      
+      // 위로 드래그하거나 빠르게 스와이프한 경우 숨기기
+      if (translationY < -50 || velocityY < -500) {
+        // 위로 사라지는 애니메이션
+        Animated.parallel([
+          Animated.timing(slideAnim, {
+            toValue: -200,
+            duration: 200,
+            useNativeDriver: true,
+          }),
+          Animated.timing(fadeAnim, {
+            toValue: 0,
+            duration: 200,
+            useNativeDriver: true,
+          }),
+        ]).start(() => {
+          onDismiss();
+        });
+      } else {
+        // 원래 위치로 복귀
+        Animated.spring(panY, {
+          toValue: 0,
+          useNativeDriver: true,
+        }).start();
+      }
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View
+      style={{
+        opacity: fadeAnim,
+        transform: [
+          { translateY: slideAnim },
+          { translateY: panY }
+        ],
+        paddingTop: statusBarHeight,
+      }}
+      className="absolute top-0 left-0 right-0 z-50"
+    >
+      <PanGestureHandler
+        onGestureEvent={onGestureEvent}
+        onHandlerStateChange={onHandlerStateChange}
+      >
+        <Animated.View>
+          <TouchableOpacity
+            onPress={onPress}
+            activeOpacity={0.8}
+            className="mx-4 mt-2 bg-white rounded-xl shadow-lg border border-gray-100"
+            style={{ elevation: 10 }}
+          >
+        <View className="p-4">
+          <View className="flex-row items-start">
+            {/* 아이콘 */}
+            <View className="w-8 h-8 bg-mainOrange rounded-full items-center justify-center mr-3 mt-0.5">
+              <Feather name={icon} size={16} color="white" />
+            </View>
+
+            {/* 내용 */}
+            <View className="flex-1 mr-2">
+              <Text className="text-base font-semibold text-gray-900 mb-1" numberOfLines={1}>
+                {title}
+              </Text>
+              <Text className="text-sm text-gray-600" numberOfLines={2}>
+                {body}
+              </Text>
+            </View>
+
+            {/* 닫기 버튼 */}
+            <TouchableOpacity
+              onPress={hideBanner}
+              className="w-6 h-6 items-center justify-center"
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Feather name="x" size={16} color="#9CA3AF" />
+            </TouchableOpacity>
+          </View>
+          </View>
+          </TouchableOpacity>
+        </Animated.View>
+      </PanGestureHandler>
+    </Animated.View>
+  );
+}

--- a/moigoFront/src/hooks/usePushNotifications.ts
+++ b/moigoFront/src/hooks/usePushNotifications.ts
@@ -2,13 +2,49 @@ import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
+import { useEffect, useRef, useState } from 'react';
+
+// 푸시 알림 데이터 타입 정의
+interface PushNotificationData {
+  type: string;
+  chatId?: string;
+  eventId?: string;
+  reservationId?: number;
+  messageId?: string;
+  senderId?: string;
+  senderName?: string;
+  text?: string;
+  amount?: number;
+  dueAtISO?: string;
+  timeISO?: string;
+  storeName?: string;
+  reason?: string;
+  canceledBy?: string;
+  paymentId?: string;
+  refundId?: string;
+  storeId?: string;
+  payoutId?: string;
+  meta?: any;
+}
+
+// 푸시 알림 핸들러 props
+interface PushNotificationHandlerProps {
+  onNavigate: (screen: string, params?: any) => void;
+  onShowBanner: (title: string, body: string, onPress: () => void) => void;
+  onSaveNotification?: (notification: { type: string; title: string; body: string; data: any }) => void;
+  currentUserType?: 'user' | 'business' | 'sports_fan';
+}
 
 function handleRegistrationError(errorMessage: string) {
   console.error('Push Notification Error:', errorMessage);
   throw new Error(errorMessage);
 }
 
-export function usePushNotifications() {
+export function usePushNotifications(handlers?: PushNotificationHandlerProps) {
+  const [expoPushToken, setExpoPushToken] = useState<string | null>(null);
+  const responseListener = useRef<Notifications.Subscription | undefined>(undefined);
+  const notificationListener = useRef<Notifications.Subscription | undefined>(undefined);
+
   // 푸시 알림 등록
   const registerForPushNotificationsAsync = async () => {
     if (Platform.OS === 'android') {
@@ -50,6 +86,7 @@ export function usePushNotifications() {
         ).data;
         
         console.log('Push Token:', pushTokenString);
+        setExpoPushToken(pushTokenString);
         return pushTokenString;
       } catch (e: unknown) {
         handleRegistrationError(`${e}`);
@@ -61,7 +98,144 @@ export function usePushNotifications() {
     }
   };
 
+  // 푸시 알림 데이터를 파싱해서 네비게이션 처리
+  const handleNotificationNavigation = (data: PushNotificationData) => {
+    if (!handlers) return;
+
+    console.log('푸시 알림 데이터:', data);
+
+    switch (data.type) {
+      case 'CHAT_MESSAGE':
+        if (data.chatId) {
+          handlers.onNavigate('ChatRoom', { chatId: data.chatId });
+        }
+        break;
+
+      case 'PAYMENT_REQUEST':
+        if (data.chatId) {
+          handlers.onNavigate('ChatRoom', { chatId: data.chatId });
+          // TODO: PaymentModal 자동 열기 로직 추가 필요
+        }
+        break;
+
+      case 'RESERVATION_CONFIRMED':
+      case 'RESERVATION_REJECTED':
+      case 'RESERVATION_CANCELED':
+        if (data.eventId) {
+          handlers.onNavigate('Meeting', { eventId: data.eventId });
+        } else if (data.chatId) {
+          handlers.onNavigate('ChatRoom', { chatId: data.chatId });
+        }
+        break;
+
+      case 'PAYMENT_SUCCESS':
+      case 'PAYMENT_FAILED':
+        if (data.chatId) {
+          handlers.onNavigate('ChatRoom', { chatId: data.chatId });
+        }
+        break;
+
+      case 'REFUND_COMPLETED':
+        handlers.onNavigate('ParticipatedMatches', {});
+        break;
+
+      // 사업자용 알림
+      case 'RESERVATION_REQUESTED':
+      case 'PAYOUT_COMPLETED':
+        if (handlers.currentUserType === 'business') {
+          handlers.onNavigate('Main', {});
+        }
+        break;
+
+      default:
+        console.log('알 수 없는 푸시 알림 타입:', data.type);
+    }
+  };
+
+  // 포그라운드에서 알림 수신 시 배너 표시
+  const handleForegroundNotification = (notification: Notifications.Notification) => {
+    if (!handlers) return;
+
+    const { title, body, data } = notification.request.content;
+    const notificationData = data as unknown as PushNotificationData;
+
+    console.log('포그라운드 알림 수신:', { title, body, data });
+
+    // 알림을 Store에 저장
+    if (handlers.onSaveNotification) {
+      handlers.onSaveNotification({
+        type: notificationData.type,
+        title: title || '새 알림',
+        body: body || '내용을 확인해주세요',
+        data: notificationData,
+      });
+    }
+
+    // 배너 표시
+    handlers.onShowBanner(
+      title || '새 알림',
+      body || '내용을 확인해주세요',
+      () => handleNotificationNavigation(notificationData)
+    );
+  };
+
+  // 알림 클릭 시 처리 (백그라운드/포그라운드 모두)
+  const handleNotificationResponse = (response: Notifications.NotificationResponse) => {
+    const { title, body, data } = response.notification.request.content;
+    const notificationData = data as unknown as PushNotificationData;
+    
+    console.log('알림 클릭됨:', notificationData);
+
+    // 백그라운드에서 받은 알림도 Store에 저장 (중복 방지 로직 포함)
+    if (handlers?.onSaveNotification) {
+      handlers.onSaveNotification({
+        type: notificationData.type,
+        title: title || '새 알림',
+        body: body || '내용을 확인해주세요',
+        data: notificationData,
+      });
+    }
+
+    handleNotificationNavigation(notificationData);
+  };
+
+  // 알림 핸들러 설정
+  useEffect(() => {
+    // 포그라운드에서 알림을 어떻게 표시할지 설정
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: false, // 시스템 알림 비활성화 (우리 배너 사용)
+        shouldPlaySound: true,
+        shouldSetBadge: false,
+        shouldShowBanner: false,
+        shouldShowList: false,
+      }),
+    });
+
+    if (handlers) {
+      // 포그라운드에서 알림 수신 시
+      notificationListener.current = Notifications.addNotificationReceivedListener(
+        handleForegroundNotification
+      );
+
+      // 알림 클릭 시 (백그라운드/포그라운드 모두)
+      responseListener.current = Notifications.addNotificationResponseReceivedListener(
+        handleNotificationResponse
+      );
+    }
+
+    return () => {
+      if (notificationListener.current) {
+        notificationListener.current.remove();
+      }
+      if (responseListener.current) {
+        responseListener.current.remove();
+      }
+    };
+  }, [handlers]);
+
   return {
+    expoPushToken,
     registerForPushNotificationsAsync,
   };
 }

--- a/moigoFront/src/layout/BusinessHeader.tsx
+++ b/moigoFront/src/layout/BusinessHeader.tsx
@@ -25,7 +25,7 @@ export default function BusinessHeader({ currentScreen }: BusinessHeaderProps) {
         
         <TouchableOpacity 
           className="p-2 bg-gray-700 rounded-full"
-          onPress={() => console.log('알림 페이지로 이동')}
+          onPress={() => navigation.navigate('Notification')}
         >
           <Feather 
             name="bell" 

--- a/moigoFront/src/layout/Header.tsx
+++ b/moigoFront/src/layout/Header.tsx
@@ -1,10 +1,11 @@
-import { View, Image, TouchableOpacity } from 'react-native';
+import { View, Image, TouchableOpacity, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Feather from 'react-native-vector-icons/Feather';
 import { COLORS } from '@/constants/colors';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '@/types/RootStackParamList';
+import { useNotificationStore } from '@/store/notificationStore';
 
 interface HeaderProps {
   currentScreen?: 'home' | 'meeting' | 'chat' | 'my';
@@ -12,6 +13,7 @@ interface HeaderProps {
 
 export default function Header({ currentScreen = 'home' }: HeaderProps) {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { unreadCount } = useNotificationStore();
   const isMyScreen = currentScreen === 'my';
   
   const handleRightButtonPress = () => {
@@ -20,7 +22,7 @@ export default function Header({ currentScreen = 'home' }: HeaderProps) {
       navigation.navigate('MyInfoSetting');
     } else {
       // 알림 페이지로 이동
-      console.log('알림 페이지로 이동');
+      navigation.navigate('Notification');
     }
   };
 
@@ -34,16 +36,27 @@ export default function Header({ currentScreen = 'home' }: HeaderProps) {
           />
         </TouchableOpacity>
         
-        <TouchableOpacity 
-          className="p-2 rounded-full bg-mainGray"
-          onPress={handleRightButtonPress}
-        >
-          <Feather 
-            name={isMyScreen ? "settings" : "bell"} 
-            size={20} 
-            color={COLORS.mainDarkGray} 
-          />
-        </TouchableOpacity>
+        <View className="relative">
+          <TouchableOpacity 
+            className="p-2 rounded-full bg-mainGray"
+            onPress={handleRightButtonPress}
+          >
+            <Feather 
+              name={isMyScreen ? "settings" : "bell"} 
+              size={20} 
+              color={COLORS.mainDarkGray} 
+            />
+          </TouchableOpacity>
+          
+          {/* 읽지 않은 알림 뱃지 */}
+          {!isMyScreen && unreadCount > 0 && (
+            <View className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full items-center justify-center">
+              <Text className="text-xs font-bold text-white">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </Text>
+            </View>
+          )}
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/moigoFront/src/navigation/RootNavigator.tsx
+++ b/moigoFront/src/navigation/RootNavigator.tsx
@@ -25,6 +25,7 @@ import BusinessHoursScreen from '@/screens/business/Setting/BusinessHoursScreen'
 import ReservationTimeScreen from '@/screens/business/Setting/ReservationTimeScreen';
 import BusinessInfoEditScreen from '@/screens/business/Setting/BusinessInfoEditScreen';
 import ChatScreen from '@/screens/ChatScreen';
+import NotificationScreen from '@/screens/NotificationScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -52,6 +53,7 @@ export const linking: LinkingOptions<RootStackParamList> = {
       Profile: 'user/profile',
       ParticipatedMatches: 'user/participated-matches',
       ChangePassword: 'user/change-password',
+      Notification: 'notification',
       
       // 사업자 전용 경로
       StoreBasicInfo: 'business/basic-info',
@@ -149,6 +151,11 @@ export default function RootNavigator() {
               headerShown: true,
               header: () => <CustomHeader title="채팅" />,
             }} 
+          />
+          <Stack.Screen 
+            name="Notification" 
+            component={NotificationScreen} 
+            options={{ headerShown: false }} 
           />
         </>
       ) : (

--- a/moigoFront/src/navigation/RootNavigator.tsx
+++ b/moigoFront/src/navigation/RootNavigator.tsx
@@ -1,6 +1,7 @@
 // src/navigation/RootNavigator.tsx
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { LinkingOptions } from '@react-navigation/native';
 import MainTabNavigator from './MainTabNavigator';
 import OnboardingScreen from '@/screens/OnboardingScreen';
 import LoginScreen from '@/screens/LoginScreen';
@@ -26,6 +27,42 @@ import BusinessInfoEditScreen from '@/screens/business/Setting/BusinessInfoEditS
 import ChatScreen from '@/screens/ChatScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+// 딥링크 설정
+export const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: ['moigo://', 'https://moigo.com'],
+  config: {
+    screens: {
+      // 로그인 관련 (공통)
+      Login: 'login',
+      Signup: 'signup',
+      Onboarding: 'onboarding',
+      
+      // 메인 화면 (공통 - 사용자 타입에 따라 분기)
+      Main: 'main',
+      
+      // 공통 기능 (사용자/사업자 모두 사용)
+      ChatRoom: 'chat/:chatId',
+      Chat: 'chat',
+      
+      // 사용자 전용 경로
+      Meeting: 'user/meeting/:eventId',
+      CreateMeeting: 'user/create-meeting',
+      MyInfoSetting: 'user/settings',
+      Profile: 'user/profile',
+      ParticipatedMatches: 'user/participated-matches',
+      ChangePassword: 'user/change-password',
+      
+      // 사업자 전용 경로
+      StoreBasicInfo: 'business/basic-info',
+      StoreDetailInfo: 'business/detail-info',
+      SportsRegistration: 'business/sports',
+      BusinessHours: 'business/hours',
+      ReservationTime: 'business/reservation-time',
+      BusinessInfoEdit: 'business/edit',
+      },
+    },
+};
 
 export default function RootNavigator() {
   const { isLoggedIn, user } = useAuthStore();

--- a/moigoFront/src/screens/LoginScreen.tsx
+++ b/moigoFront/src/screens/LoginScreen.tsx
@@ -13,6 +13,7 @@ export default function LoginScreen() {
   const { login, selectedUserType, setLoading, isLoading } = useAuthStore();
   const [userId, setUserId] = useState('');
   const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(true); // 자동 로그인 기본값 true
 
   // 로그인 훅들
   const loginMutation = useLogin();
@@ -129,6 +130,23 @@ export default function LoginScreen() {
             editable={!isLoading}
           />
         </View>
+      </View>
+
+      {/* 자동 로그인 체크박스 */}
+      <View className="flex-row items-center mb-4 w-full">
+        <TouchableOpacity 
+          onPress={() => setRememberMe(!rememberMe)}
+          className="flex-row items-center"
+        >
+          <View className={`w-5 h-5 rounded border-2 mr-2 items-center justify-center ${
+            rememberMe ? 'bg-mainOrange border-mainOrange' : 'border-gray-300'
+          }`}>
+            {rememberMe && (
+              <Text className="text-white text-xs font-bold">✓</Text>
+            )}
+          </View>
+          <Text className="text-gray-600">자동 로그인</Text>
+        </TouchableOpacity>
       </View>
 
       {/* 로그인 버튼 */}

--- a/moigoFront/src/screens/NotificationScreen.tsx
+++ b/moigoFront/src/screens/NotificationScreen.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { Feather } from '@expo/vector-icons';
+import { useNotificationStore, getNotificationIcon, getNotificationColor } from '@/store/notificationStore';
+import type { NotificationItem } from '@/store/notificationStore';
+
+// 시간 포맷팅 함수
+const formatTime = (timestamp: Date): string => {
+  const now = new Date();
+  const diff = now.getTime() - timestamp.getTime();
+  const minutes = Math.floor(diff / (1000 * 60));
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (minutes < 1) return '방금 전';
+  if (minutes < 60) return `${minutes}분 전`;
+  if (hours < 24) return `${hours}시간 전`;
+  if (days < 7) return `${days}일 전`;
+  
+  return timestamp.toLocaleDateString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+// 개별 알림 아이템 컴포넌트
+interface NotificationItemProps {
+  notification: NotificationItem;
+  onPress: () => void;
+  onDelete: () => void;
+}
+
+function NotificationItemComponent({ notification, onPress, onDelete }: NotificationItemProps) {
+  const iconName = getNotificationIcon(notification.type);
+  const iconColor = getNotificationColor(notification.type);
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className={`flex-row p-4 border-b border-gray-100 ${!notification.isRead ? 'bg-blue-50' : 'bg-white'}`}
+      activeOpacity={0.7}
+    >
+      {/* 읽지 않은 알림 표시 점 */}
+      {!notification.isRead && (
+        <View className="w-2 h-2 bg-blue-500 rounded-full mt-2 mr-3" />
+      )}
+      
+      {/* 아이콘 */}
+      <View 
+        className="w-12 h-12 rounded-full items-center justify-center mr-3"
+        style={{ backgroundColor: iconColor + '20' }}
+      >
+        <Feather name={iconName as any} size={20} color={iconColor} />
+      </View>
+
+      {/* 알림 내용 */}
+      <View className="flex-1">
+        <Text className={`text-base ${!notification.isRead ? 'font-semibold text-gray-900' : 'font-medium text-gray-600'}`}>
+          {notification.title}
+        </Text>
+        <Text className={`text-sm mt-1 ${!notification.isRead ? 'text-gray-700' : 'text-gray-500'}`} numberOfLines={2}>
+          {notification.body}
+        </Text>
+        <Text className="text-xs text-gray-400 mt-2">
+          {formatTime(notification.timestamp)}
+        </Text>
+      </View>
+
+      {/* 삭제 버튼 */}
+      <TouchableOpacity
+        onPress={onDelete}
+        className="p-2 ml-2"
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      >
+        <Feather name="x" size={16} color="#9CA3AF" />
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}
+
+export default function NotificationScreen() {
+  const navigation = useNavigation();
+  const { 
+    notifications, 
+    unreadCount, 
+    markAsRead, 
+    markAllAsRead, 
+    deleteNotification, 
+    clearAll 
+  } = useNotificationStore();
+
+  // 알림 클릭 처리
+  const handleNotificationPress = (notification: NotificationItem) => {
+    // 읽음 처리
+    if (!notification.isRead) {
+      markAsRead(notification.id);
+    }
+
+    // TODO: 알림 타입별 네비게이션 처리
+    // 현재는 단순히 뒤로가기
+    navigation.goBack();
+  };
+
+  // 알림 삭제 처리
+  const handleDeleteNotification = (notification: NotificationItem) => {
+    Alert.alert(
+      '알림 삭제',
+      '이 알림을 삭제하시겠습니까?',
+      [
+        { text: '취소', style: 'cancel' },
+        { 
+          text: '삭제', 
+          style: 'destructive',
+          onPress: () => deleteNotification(notification.id) 
+        },
+      ]
+    );
+  };
+
+  // 전체 삭제 처리
+  const handleClearAll = () => {
+    Alert.alert(
+      '전체 삭제',
+      '모든 알림을 삭제하시겠습니까?',
+      [
+        { text: '취소', style: 'cancel' },
+        { 
+          text: '전체 삭제', 
+          style: 'destructive',
+          onPress: clearAll 
+        },
+      ]
+    );
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      {/* 헤더 */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-gray-200">
+        <View className="flex-row items-center">
+          <TouchableOpacity 
+            onPress={() => navigation.goBack()}
+            className="mr-3"
+          >
+            <Feather name="arrow-left" size={24} color="#374151" />
+          </TouchableOpacity>
+          <Text className="text-xl font-bold text-gray-900">알림</Text>
+          {unreadCount > 0 && (
+            <View className="ml-2 px-2 py-1 bg-red-500 rounded-full">
+              <Text className="text-xs font-bold text-white">{unreadCount}</Text>
+            </View>
+          )}
+        </View>
+
+        {/* 헤더 액션 버튼들 */}
+        <View className="flex-row">
+          {unreadCount > 0 && (
+            <TouchableOpacity
+              onPress={markAllAsRead}
+              className="px-3 py-1 mr-2"
+            >
+              <Text className="text-sm font-medium text-blue-600">모두 읽음</Text>
+            </TouchableOpacity>
+          )}
+          {notifications.length > 0 && (
+            <TouchableOpacity onPress={handleClearAll}>
+              <Feather name="trash-2" size={20} color="#EF4444" />
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      {/* 알림 목록 */}
+      {notifications.length === 0 ? (
+        <View className="flex-1 justify-center items-center px-4">
+          <Feather name="bell" size={64} color="#D1D5DB" />
+          <Text className="text-lg font-medium text-gray-500 mt-4">알림이 없습니다</Text>
+          <Text className="text-sm text-gray-400 text-center mt-2">
+            새로운 알림이 오면 여기에 표시됩니다
+          </Text>
+        </View>
+      ) : (
+        <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+          {notifications.map((notification) => (
+            <NotificationItemComponent
+              key={notification.id}
+              notification={notification}
+              onPress={() => handleNotificationPress(notification)}
+              onDelete={() => handleDeleteNotification(notification)}
+            />
+          ))}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}

--- a/moigoFront/src/store/authStore.ts
+++ b/moigoFront/src/store/authStore.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { PasswordChangeForm, PasswordValidation } from '@/types/reservation';
 
 // 로그인 사용자 타입 정의 - 서버 응답에 맞게 수정
@@ -28,16 +30,19 @@ interface AuthState {
   setUserType: (userType: 'sports_fan' | 'business') => void; // 사용자 타입 설정
   changePassword: (passwordData: PasswordChangeForm) => Promise<boolean>;
   validatePassword: (password: string) => PasswordValidation;
+  checkAutoLogin: () => Promise<boolean>; // 자동 로그인 체크
 }
 
 // 인증 스토어 생성
-export const useAuthStore = create<AuthState>((set, get) => ({
-  // 초기 상태 - 로그아웃 상태로 시작
-  isLoggedIn: false,
-  user: null,
-  isLoading: false,
-  token: null,
-  selectedUserType: null,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      // 초기 상태 - 로그아웃 상태로 시작
+      isLoggedIn: false,
+      user: null,
+      isLoading: false,
+      token: null,
+      selectedUserType: null,
   
   // 로그인 액션 - 서버 응답에 맞게 수정
   login: (userData: AuthUser, token: string) => {
@@ -57,6 +62,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       token: null,
       isLoading: false,
     });
+    // AsyncStorage에서도 제거
+    AsyncStorage.removeItem('auth-storage');
   },
   
   // 로딩 상태 설정
@@ -124,4 +131,64 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       errors,
     };
   },
-}));
+
+  // 자동 로그인 체크
+  checkAutoLogin: async (): Promise<boolean> => {
+    const { token, user } = get();
+    
+    if (!token || !user) {
+      return false;
+    }
+
+    set({ isLoading: true });
+
+    try {
+      // TODO: 실제 API 호출로 토큰 유효성 검사
+      // const response = await fetch('/api/auth/verify', {
+      //   headers: { Authorization: `Bearer ${token}` }
+      // });
+      
+      // 개발용: 간단한 토큰 유효성 체크 (실제로는 서버에서 검증)
+      const isValidToken = token.startsWith('jwt-token-') || token.startsWith('new-jwt-token-');
+      
+      if (isValidToken) {
+        set({ 
+          isLoggedIn: true,
+          isLoading: false 
+        });
+        return true;
+      } else {
+        // 토큰이 유효하지 않으면 로그아웃
+        set({
+          isLoggedIn: false,
+          user: null,
+          token: null,
+          isLoading: false,
+        });
+        return false;
+      }
+    } catch (error) {
+      console.error('자동 로그인 체크 실패:', error);
+      set({
+        isLoggedIn: false,
+        user: null,
+        token: null,
+        isLoading: false,
+      });
+      return false;
+    }
+  },
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      // 보안상 토큰만 저장하고 민감한 정보는 제외
+      partialize: (state) => ({
+        isLoggedIn: state.isLoggedIn,
+        user: state.user,
+        token: state.token,
+        selectedUserType: state.selectedUserType,
+      }),
+    }
+  )
+);

--- a/moigoFront/src/store/notificationStore.ts
+++ b/moigoFront/src/store/notificationStore.ts
@@ -1,0 +1,166 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// 알림 아이템 타입 정의
+export interface NotificationItem {
+  id: string;
+  type: 'CHAT_MESSAGE' | 'PAYMENT_REQUEST' | 'RESERVATION_CONFIRMED' | 'RESERVATION_REJECTED' | 'RESERVATION_CANCELED' | 'PAYMENT_SUCCESS' | 'PAYMENT_FAILED' | 'REFUND_COMPLETED' | 'RESERVATION_REQUESTED' | 'PAYOUT_COMPLETED';
+  title: string;
+  body: string;
+  timestamp: Date;
+  isRead: boolean;
+  data: any; // 원본 푸시 데이터
+}
+
+// 알림 Store 타입
+interface NotificationStore {
+  notifications: NotificationItem[];
+  unreadCount: number;
+  
+  // Actions
+  addNotification: (notification: Omit<NotificationItem, 'id' | 'timestamp' | 'isRead'>) => void;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  deleteNotification: (id: string) => void;
+  clearAll: () => void;
+  getUnreadCount: () => number;
+}
+
+// 알림 타입별 아이콘 반환
+export const getNotificationIcon = (type: NotificationItem['type']): string => {
+  switch (type) {
+    case 'CHAT_MESSAGE':
+      return 'message-circle';
+    case 'PAYMENT_REQUEST':
+    case 'PAYMENT_SUCCESS':
+    case 'PAYMENT_FAILED':
+      return 'credit-card';
+    case 'RESERVATION_CONFIRMED':
+    case 'RESERVATION_REQUESTED':
+      return 'check-circle';
+    case 'RESERVATION_REJECTED':
+    case 'RESERVATION_CANCELED':
+      return 'x-circle';
+    case 'REFUND_COMPLETED':
+    case 'PAYOUT_COMPLETED':
+      return 'dollar-sign';
+    default:
+      return 'bell';
+  }
+};
+
+// 알림 타입별 색상 반환
+export const getNotificationColor = (type: NotificationItem['type']): string => {
+  switch (type) {
+    case 'CHAT_MESSAGE':
+      return '#3B82F6'; // 파란색
+    case 'PAYMENT_REQUEST':
+    case 'PAYMENT_FAILED':
+      return '#EF4444'; // 빨간색
+    case 'PAYMENT_SUCCESS':
+    case 'RESERVATION_CONFIRMED':
+      return '#10B981'; // 초록색
+    case 'RESERVATION_REJECTED':
+    case 'RESERVATION_CANCELED':
+      return '#F59E0B'; // 주황색
+    case 'REFUND_COMPLETED':
+    case 'PAYOUT_COMPLETED':
+      return '#8B5CF6'; // 보라색
+    case 'RESERVATION_REQUESTED':
+      return '#06B6D4'; // 하늘색
+    default:
+      return '#6B7280'; // 회색
+  }
+};
+
+export const useNotificationStore = create<NotificationStore>()(
+  persist(
+    (set, get) => ({
+      notifications: [],
+      unreadCount: 0,
+
+      addNotification: (notification) => {
+        const newNotification: NotificationItem = {
+          ...notification,
+          id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
+          timestamp: new Date(),
+          isRead: false,
+        };
+
+        set((state) => {
+          const newNotifications = [newNotification, ...state.notifications];
+          const unreadCount = newNotifications.filter(n => !n.isRead).length;
+          
+          return {
+            notifications: newNotifications,
+            unreadCount,
+          };
+        });
+      },
+
+      markAsRead: (id) => {
+        set((state) => {
+          const updatedNotifications = state.notifications.map(notification =>
+            notification.id === id
+              ? { ...notification, isRead: true }
+              : notification
+          );
+          const unreadCount = updatedNotifications.filter(n => !n.isRead).length;
+          
+          return {
+            notifications: updatedNotifications,
+            unreadCount,
+          };
+        });
+      },
+
+      markAllAsRead: () => {
+        set((state) => ({
+          notifications: state.notifications.map(notification => ({
+            ...notification,
+            isRead: true,
+          })),
+          unreadCount: 0,
+        }));
+      },
+
+      deleteNotification: (id) => {
+        set((state) => {
+          const updatedNotifications = state.notifications.filter(n => n.id !== id);
+          const unreadCount = updatedNotifications.filter(n => !n.isRead).length;
+          
+          return {
+            notifications: updatedNotifications,
+            unreadCount,
+          };
+        });
+      },
+
+      clearAll: () => {
+        set({
+          notifications: [],
+          unreadCount: 0,
+        });
+      },
+
+      getUnreadCount: () => {
+        return get().notifications.filter(n => !n.isRead).length;
+      },
+    }),
+    {
+      name: 'notification-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      // timestamp를 Date 객체로 복원
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.notifications = state.notifications.map(notification => ({
+            ...notification,
+            timestamp: new Date(notification.timestamp),
+          }));
+          state.unreadCount = state.notifications.filter(n => !n.isRead).length;
+        }
+      },
+    }
+  )
+);

--- a/moigoFront/src/types/RootStackParamList.ts
+++ b/moigoFront/src/types/RootStackParamList.ts
@@ -20,4 +20,5 @@ export type RootStackParamList = {
   Profile: undefined;
   ChangePassword: undefined;
   Favorite: undefined;
+  Notification: undefined;
 };


### PR DESCRIPTION
### 2.1 채팅 메시지 수신 (CHAT_MESSAGE)
- **수정된 딥링크**: `moigo://chat/{chatId}`
- **필요한 파라미터**: 
  - `chatId: string` (ChatRoomScreen에서 route.params.chatId로 받음)
- **데이터 필드**: `chatId`, `messageId`, `senderId`, `senderName`, `text`
- **Frontend 처리**: ChatRoomScreen으로 이동

### 2.2 결제 요청 (PAYMENT_REQUEST)  
- **수정된 딥링크**: `moigo://chat/{chatId}` (기존 채팅방으로 이동)
- **필요한 파라미터**:
  - `chatId: string` (ChatRoomScreen 파라미터)
- **데이터 필드**: `reservationId`, `chatId`, `amount`, `dueAtISO`
- **Frontend 처리**: 
  - 채팅방으로 이동 후 PaymentModal 자동 열기
  - 또는 별도 결제 화면 개발 필요

### 2.3 예약 확정 (RESERVATION_CONFIRMED)
- **수정된 딥링크**: `moigo://user/meeting/{eventId}`
- **필요한 파라미터**:
  - `eventId: string` (MeetingScreen에서 route.params.eventId로 받음)
- **데이터 필드**: `reservationId`, `eventId`, `chatId`, `timeISO`, `storeName`
- **Frontend 처리**: MeetingScreen으로 이동

### 2.4 예약 거절 (RESERVATION_REJECTED)
- **수정된 딥링크**: `moigo://chat/{chatId}`
- **필요한 파라미터**:
  - `chatId: string`
- **데이터 필드**: `reservationId`, `chatId`, `storeName`, `reason`
- **Frontend 처리**: 채팅방으로 이동 후 거절 사유 토스트/알림 표시

### 2.5 모임 취소 (RESERVATION_CANCELED)
- **수정된 딥링크**: `moigo://chat/{chatId}`
- **필요한 파라미터**:
  - `chatId: string`
- **데이터 필드**: `reservationId`, `chatId`, `canceledBy`
- **Frontend 처리**: 채팅방으로 이동 후 취소 알림 표시

### 2.6 결제 완료 (PAYMENT_SUCCESS)
- **수정된 딥링크**: `moigo://chat/{chatId}`
- **필요한 파라미터**:
  - `chatId: string`
- **데이터 필드**: `paymentId`, `reservationId`, `chatId`, `amount`
- **Frontend 처리**: 채팅방으로 이동 후 성공 토스트 표시

### 2.7 환불 완료 (REFUND_COMPLETED)
- **수정된 딥링크**: `moigo://user/participated-matches` (참여한 매칭 이력)
- **필요한 파라미터**: 없음
- **데이터 필드**: `refundId`, `reservationId`, `amount`
- **Frontend 처리**: 참여한 매칭 이력 화면으로 이동

### 2.8 결제 실패 (PAYMENT_FAILED)
- **수정된 딥링크**: `moigo://chat/{chatId}`
- **필요한 파라미터**:
  - `chatId: string`
- **데이터 필드**: `reservationId`, `chatId`, `reason`
- **Frontend 처리**: 채팅방으로 이동 후 PaymentModal 다시 열기

---

## 3. 사장님(Store Owner) 알림

### 3.1 예약 요청 (RESERVATION_REQUESTED)
- **수정된 딥링크**: `moigo://main` (BusinessHomeScreen으로 이동)
- **필요한 파라미터**: 없음 (Main 화면에서 사업자 타입 확인 후 BusinessHomeScreen 표시)
- **데이터 필드**: `reservationId`, `storeId`, `meta`
- **Frontend 처리**: 
  - BusinessHomeScreen으로 이동
  - 해당 예약을 하이라이트하거나 AcceptModal/RejectModal 자동 열기

### 3.2 정산 완료 (PAYOUT_COMPLETED)
- **수정된 딥링크**: `moigo://main` (BusinessHomeScreen으로 이동)
- **필요한 파라미터**: 없음
- **데이터 필드**: `payoutId`, `reservationId`, `amount`
- **Frontend 처리**: 
  - BusinessHomeScreen으로 이동
  - 정산 완료 토스트 표시
  - (향후) 별도 정산 화면 개발 시 해당 화면으로 이동
