### PR TITLE
feat: 이미지 삽입 커스텀 훅

### DIFF
--- a/moigoFront/package-lock.json
+++ b/moigoFront/package-lock.json
@@ -23,6 +23,7 @@
         "expo": "53.0.20",
         "expo-constants": "~17.1.7",
         "expo-device": "~7.1.4",
+        "expo-image-picker": "^16.1.4",
         "expo-linear-gradient": "^14.1.5",
         "expo-notifications": "~0.31.4",
         "expo-status-bar": "~2.2.3",
@@ -7376,6 +7377,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/moigoFront/package.json
+++ b/moigoFront/package.json
@@ -23,8 +23,8 @@
     "date-fns": "^4.1.0",
     "expo": "53.0.20",
     "expo-constants": "~17.1.7",
-
     "expo-device": "~7.1.4",
+    "expo-image-picker": "^16.1.4",
     "expo-linear-gradient": "^14.1.5",
     "expo-notifications": "~0.31.4",
     "expo-status-bar": "~2.2.3",

--- a/moigoFront/src/components/profile/ProfileImage.tsx
+++ b/moigoFront/src/components/profile/ProfileImage.tsx
@@ -3,7 +3,7 @@ import { View, Text, TouchableOpacity, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 interface ProfileImageProps {
-  imageUri?: string;
+  imageUri: string | null;
   onImageChange: () => void;
 }
 
@@ -11,16 +11,16 @@ export default function ProfileImage({ imageUri, onImageChange }: ProfileImagePr
   return (
     <View className="items-center mb-6">
       <View className="relative">
-        <View className="items-center justify-center w-24 h-24 overflow-hidden bg-gray-200 rounded-full">
-          {imageUri ? (
-            <Image source={{ uri: imageUri }} className="w-full h-full" resizeMode="cover" />
+        <View className="overflow-hidden justify-center items-center w-24 h-24 bg-gray-200 rounded-full">
+          {imageUri !== null ? (
+            <Image source={{ uri: imageUri as string }} className="w-full h-full" resizeMode="cover" />
           ) : (
             <Ionicons name="person" size={48} color="#9CA3AF" />
           )}
         </View>
 
         <TouchableOpacity
-          className="absolute bottom-0 right-0 items-center justify-center w-8 h-8 rounded-full bg-mainOrange"
+          className="absolute right-0 bottom-0 justify-center items-center w-8 h-8 rounded-full bg-mainOrange"
           onPress={onImageChange}
         >
           <Ionicons name="camera" size={16} color="white" />

--- a/moigoFront/src/hooks/useImagePicker.ts
+++ b/moigoFront/src/hooks/useImagePicker.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import * as ImagePicker from 'expo-image-picker';
+
+type UseImagePickerResult = {
+  image: string | null;
+  error: string | null;
+  pickImage: () => Promise<void>;
+  setImage: (uri: string | null) => void;
+};
+
+export function useImagePicker(): UseImagePickerResult {
+  const [image, setImage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const pickImage = async (): Promise<void> => {
+    try {
+      const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permissionResult.granted) {
+        setError('사진 접근 권한이 필요합니다.');
+        return;
+      }
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 1,
+      });
+      if (!result.canceled && result.assets && result.assets.length > 0) {
+        setImage(result.assets[0].uri);
+        setError(null);
+      } else if (result.canceled) {
+        setError('이미지 선택이 취소되었습니다.');
+      } else {
+        setError('이미지를 불러오는 데 실패했습니다.');
+      }
+    } catch (e: any) {
+      setError(e?.message || '알 수 없는 오류 발생');
+    }
+  };
+
+  return { image, error, pickImage, setImage };
+}

--- a/moigoFront/src/hooks/useProfile.ts
+++ b/moigoFront/src/hooks/useProfile.ts
@@ -5,10 +5,12 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '@/types/RootStackParamList';
 import { useUpdateProfile } from '@/hooks/queries/useUserQueries';
+import { useImagePicker } from '@/hooks/useImagePicker';
 
 export function useProfile() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { userProfile, isLoading, updateUserProfile, updateProfileImage, setLoading } = useMyStore();
+  const { image, pickImage, setImage } = useImagePicker();
   const [isEditing, setIsEditing] = useState(false);
   const [formData, setFormData] = useState<ProfileFormData>({
     name: '',
@@ -19,7 +21,7 @@ export function useProfile() {
     bio: '',
   });
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-
+  
   // React Query mutation
   const updateProfileMutation = useUpdateProfile();
 
@@ -106,6 +108,8 @@ export function useProfile() {
   const handleImageChange = (imageUri: string) => {
     if (!userProfile) return;
     updateProfileImage(imageUri);
+    // 테스트용: 선택한 이미지를 즉시 표시
+    setImage(imageUri);
   };
 
   // 성별 변경
@@ -164,9 +168,12 @@ export function useProfile() {
   // 모달에서 확인 클릭
   function handleModalClick() {
     setIsModalOpen(false);
-    navigation.navigate('Main', { screen: 'My' });
+    (navigation as any).navigate('Main', { screen: 'My' });
   }
 
+  const handleImagePress = () => {
+    pickImage();
+  };
   return {
     // 상태
     profileData: userProfile || {
@@ -186,6 +193,7 @@ export function useProfile() {
       writtenReviews: 0,
       preferredSports: [],
     },
+    image,
     formData,
     isLoading,
     isEditing,
@@ -201,5 +209,6 @@ export function useProfile() {
     handleImageChange,
     handleGenderChange,
     handleModalClick,
+    handleImagePress,
   };
 }

--- a/moigoFront/src/screens/user/Mypage/Profile.tsx
+++ b/moigoFront/src/screens/user/Mypage/Profile.tsx
@@ -9,12 +9,12 @@ import GenderSelector from '@/components/profile/GenderSelector';
 import BioTextArea from '@/components/profile/BioTextArea';
 import PrimaryButton from '@/components/common/PrimaryButton';
 import CheckModal from '@/components/common/CheckModal';
-import { COLORS } from '@/constants/colors';
 
 export default function Profile() {
   const {
     profileData,
     formData,
+    image,
     isLoading,
     isEditing,
     isFormValid,
@@ -24,18 +24,12 @@ export default function Profile() {
     cancelEditing,
     updateFormData,
     handleSave,
-    handleImageChange,
     handleGenderChange,
     handleModalClick,
+    handleImagePress,
   } = useProfile();
 
-  const handleImagePress = () => {
-    // 이미지 선택 로직 (나중에 구현)
-    Alert.alert('이미지 선택', '이미지 선택 기능은 나중에 구현됩니다.');
-  };
-
   const handleBirthDatePress = () => {
-    // 날짜 선택 로직 (나중에 구현)
     Alert.alert('날짜 선택', '날짜 선택 기능은 나중에 구현됩니다.');
   };
 
@@ -57,7 +51,7 @@ export default function Profile() {
       </CheckModal>
       <ScrollView className="flex-1 pt-8">
         {/* 프로필 이미지 */}
-        <ProfileImage imageUri={profileData.profileImage} onImageChange={handleImagePress} />
+        <ProfileImage imageUri={image} onImageChange={handleImagePress} />
 
         {/* 기본 정보 */}
         <View className="mb-2">


### PR DESCRIPTION
## 🖼️ 프로필 이미지 편집 기능 구현

### 📝 변경 사항
- **프로필 이미지 선택 및 표시 기능 추가**
  - `useImagePicker` 훅에 `setImage` 함수 export 추가
  - 프로필 편집 시 이미지 선택 즉시 화면에 반영
  - 갤러리 접근 권한 처리 및 에러 핸들링

### 🔧 주요 수정 파일
- `src/hooks/useImagePicker.ts` - 이미지 피커 훅 개선
- `src/hooks/useProfile.ts` - 프로필 이미지 변경 로직 추가
- `src/components/profile/ProfileImage.tsx` - 이미지 표시 컴포넌트
- `src/screens/user/Mypage/Profile.tsx` - 프로필 편집 화면

### ✨ 기능 상세
1. **이미지 선택**: 갤러리에서 이미지 선택 시 즉시 프로필 이미지 영역에 표시
2. **권한 관리**: 사진 접근 권한 요청 및 거부 시 적절한 에러 메시지 표시
3. **UI/UX**: 원형 이미지 표시 및 카메라 아이콘으로 변경 버튼 제공
4. **테스트 지원**: API 연동 전 UI 동작 테스트 가능

###  테스트 방법
1. 프로필 편집 화면 진입
2. "사진 변경" 버튼 클릭
3. 갤러리에서 이미지 선택
4. 선택한 이미지가 프로필 영역에 동그랗게 표시되는지 확인

### 지원 플랫폼
- iOS (개발 빌드 권장)
- Android (개발 빌드 권장)
- ExpoGo (제한적 지원)

###  관련 이슈
- 프로필 이미지 편집 기능 구현 요청
- 저장하는 api 개발중